### PR TITLE
feat: add project configuration CRUD tools

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -1664,6 +1664,224 @@ def get_issue_types(project_id: int, session_id: Optional[str] = None) -> List[D
     )
 
 
+# --- Project Configuration CRUD Tools ---
+
+# Mapping from user-facing config type to API path segment
+_PROJECT_CONFIG_TYPE_MAP = {
+    "epic_status": "epic-statuses",
+    "userstory_status": "userstory-statuses",
+    "user_story_status": "userstory-statuses",
+    "task_status": "task-statuses",
+    "issue_status": "issue-statuses",
+    "issue_type": "issue-types",
+    "priority": "priorities",
+    "severity": "severities",
+}
+_PROJECT_CONFIG_VALID_TYPES = [
+    "epic_status",
+    "issue_status",
+    "issue_type",
+    "priority",
+    "severity",
+    "task_status",
+    "userstory_status",
+]
+
+
+def _validate_project_config_type(config_type: str) -> str:
+    """Validate and normalize a project configuration type."""
+    config_type = config_type.strip().lower()
+    if config_type not in _PROJECT_CONFIG_TYPE_MAP:
+        raise ValueError(
+            f"Invalid config_type '{config_type}'. Must be one of: {_PROJECT_CONFIG_VALID_TYPES}"
+        )
+    return config_type
+
+
+@mcp.tool(
+    "create_project_config",
+    description=(
+        "Creates a project configuration item (status, type, priority, or severity). "
+        "config_type: 'epic_status', 'userstory_status', 'task_status', 'issue_status', "
+        "'issue_type', 'priority', or 'severity'. "
+        "color is a hex string (e.g. '#999999'). is_closed marks whether the status "
+        "represents a closed/done state (statuses only). "
+        "Uses default session if session_id not provided."
+    ),
+)
+def create_project_config(
+    project_id: int,
+    config_type: str,
+    name: str,
+    color: str = "#999999",
+    is_closed: Optional[bool] = None,
+    order: Optional[int] = None,
+    session_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Creates a project configuration item."""
+    config_type = _validate_project_config_type(config_type)
+    name = name.strip() if name else ""
+    if not name:
+        raise ValueError("Name cannot be empty.")
+
+    actual_session_id = _get_session_id(session_id)
+    logger.info(
+        f"Executing create_project_config '{name}' ({config_type}) in project {project_id}, "
+        f"session {actual_session_id[:8]}..."
+    )
+    taiga_client_wrapper = _get_authenticated_client(actual_session_id)
+    api_path = _PROJECT_CONFIG_TYPE_MAP[config_type]
+
+    def do_create():
+        payload: Dict[str, Any] = {
+            "project": project_id,
+            "name": name,
+            "color": color,
+        }
+        if is_closed is not None:
+            payload["is_closed"] = is_closed
+        if order is not None:
+            payload["order"] = order
+        return taiga_client_wrapper.api.post(f"/{api_path}", json=payload)
+
+    return _execute_taiga_operation(
+        "create_project_config", do_create, f"'{name}' ({config_type}) in project {project_id}"
+    )
+
+
+@mcp.tool(
+    "update_project_config",
+    description=(
+        "Updates a project configuration item (status, type, priority, or severity). "
+        "config_type: 'epic_status', 'userstory_status', 'task_status', 'issue_status', "
+        "'issue_type', 'priority', or 'severity'. "
+        "item_id is the internal ID of the configuration item. "
+        "Uses default session if session_id not provided."
+    ),
+)
+def update_project_config(
+    item_id: int,
+    config_type: str,
+    name: Optional[str] = None,
+    color: Optional[str] = None,
+    is_closed: Optional[bool] = None,
+    order: Optional[int] = None,
+    session_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Updates a project configuration item."""
+    config_type = _validate_project_config_type(config_type)
+    if name is not None:
+        name = name.strip()
+        if not name:
+            raise ValueError("Name cannot be empty.")
+    if all(v is None for v in [name, color, is_closed, order]):
+        raise ValueError("At least one field to update must be provided.")
+
+    actual_session_id = _get_session_id(session_id)
+    logger.info(
+        f"Executing update_project_config {item_id} ({config_type}), "
+        f"session {actual_session_id[:8]}..."
+    )
+    taiga_client_wrapper = _get_authenticated_client(actual_session_id)
+    api_path = _PROJECT_CONFIG_TYPE_MAP[config_type]
+
+    def do_update():
+        payload: Dict[str, Any] = {}
+        if name is not None:
+            payload["name"] = name
+        if color is not None:
+            payload["color"] = color
+        if is_closed is not None:
+            payload["is_closed"] = is_closed
+        if order is not None:
+            payload["order"] = order
+        return taiga_client_wrapper.api.patch(f"/{api_path}/{item_id}", json=payload)
+
+    return _execute_taiga_operation("update_project_config", do_update, f"{config_type} {item_id}")
+
+
+@mcp.tool(
+    "delete_project_config",
+    description=(
+        "Deletes a project configuration item (status, type, priority, or severity). "
+        "config_type: 'epic_status', 'userstory_status', 'task_status', 'issue_status', "
+        "'issue_type', 'priority', or 'severity'. "
+        "item_id is the internal ID of the configuration item. "
+        "Uses default session if session_id not provided."
+    ),
+)
+def delete_project_config(
+    item_id: int,
+    config_type: str,
+    session_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Deletes a project configuration item."""
+    config_type = _validate_project_config_type(config_type)
+
+    actual_session_id = _get_session_id(session_id)
+    logger.warning(
+        f"Executing delete_project_config {item_id} ({config_type}), "
+        f"session {actual_session_id[:8]}..."
+    )
+    taiga_client_wrapper = _get_authenticated_client(actual_session_id)
+    api_path = _PROJECT_CONFIG_TYPE_MAP[config_type]
+
+    def do_delete():
+        taiga_client_wrapper.api.delete(f"/{api_path}/{item_id}")
+        return {"status": "deleted", "item_id": item_id, "config_type": config_type}
+
+    return _execute_taiga_operation("delete_project_config", do_delete, f"{config_type} {item_id}")
+
+
+@mcp.tool(
+    "bulk_update_order_project_config",
+    description=(
+        "Bulk updates the display order of project configuration items. "
+        "config_type: 'epic_status', 'userstory_status', 'task_status', 'issue_status', "
+        "'issue_type', 'priority', or 'severity'. "
+        "bulk_orders is a list of [id, order] pairs, e.g. [[1, 1], [2, 2], [3, 3]]. "
+        "Uses default session if session_id not provided."
+    ),
+)
+def bulk_update_order_project_config(
+    project_id: int,
+    config_type: str,
+    bulk_orders: List[List[int]],
+    session_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Bulk updates the display order of project configuration items."""
+    config_type = _validate_project_config_type(config_type)
+    if not bulk_orders:
+        raise ValueError("bulk_orders cannot be empty.")
+    for pair in bulk_orders:
+        if not isinstance(pair, list) or len(pair) != 2:
+            raise ValueError(f"Each entry in bulk_orders must be a [id, order] pair, got: {pair}")
+
+    actual_session_id = _get_session_id(session_id)
+    logger.info(
+        f"Executing bulk_update_order_project_config ({config_type}) in project {project_id}, "
+        f"{len(bulk_orders)} items, session {actual_session_id[:8]}..."
+    )
+    taiga_client_wrapper = _get_authenticated_client(actual_session_id)
+    api_path = _PROJECT_CONFIG_TYPE_MAP[config_type]
+
+    def do_bulk_order():
+        payload = {"project": project_id, "bulk_orders": bulk_orders}
+        taiga_client_wrapper.api.post(f"/{api_path}/bulk_update_order", json=payload)
+        return {
+            "status": "updated",
+            "config_type": config_type,
+            "project_id": project_id,
+            "items_reordered": len(bulk_orders),
+        }
+
+    return _execute_taiga_operation(
+        "bulk_update_order_project_config",
+        do_bulk_order,
+        f"{config_type} in project {project_id}",
+    )
+
+
 # --- Story Points Tools ---
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -911,6 +911,179 @@ class TestTaigaTools:
         assert len(result) == 2
         mock_client.list_resources.assert_called_once_with("issue_types", project_id=123)
 
+    # ─── Project Configuration CRUD tests ────────────────────────────
+
+    def test_create_project_config_status(self, session_setup):
+        """Test create_project_config for issue_status."""
+        session_id, mock_client = session_setup
+        mock_client.api.post.return_value = {"id": 10, "name": "In Review"}
+        result = src.server.create_project_config(
+            21, "issue_status", "In Review", session_id=session_id
+        )
+        mock_client.api.post.assert_called_once_with(
+            "/issue-statuses",
+            json={"project": 21, "name": "In Review", "color": "#999999"},
+        )
+        assert result["name"] == "In Review"
+
+    def test_create_project_config_with_options(self, session_setup):
+        """Test create_project_config with all optional fields."""
+        session_id, mock_client = session_setup
+        mock_client.api.post.return_value = {"id": 11}
+        src.server.create_project_config(
+            21,
+            "task_status",
+            "Done",
+            color="#00FF00",
+            is_closed=True,
+            order=5,
+            session_id=session_id,
+        )
+        call_json = mock_client.api.post.call_args[1]["json"]
+        assert call_json["name"] == "Done"
+        assert call_json["color"] == "#00FF00"
+        assert call_json["is_closed"] is True
+        assert call_json["order"] == 5
+
+    def test_create_project_config_priority(self, session_setup):
+        """Test create_project_config for priority."""
+        session_id, mock_client = session_setup
+        mock_client.api.post.return_value = {"id": 12}
+        src.server.create_project_config(21, "priority", "Urgent", session_id=session_id)
+        mock_client.api.post.assert_called_once_with(
+            "/priorities",
+            json={"project": 21, "name": "Urgent", "color": "#999999"},
+        )
+
+    def test_create_project_config_severity(self, session_setup):
+        """Test create_project_config for severity."""
+        session_id, mock_client = session_setup
+        mock_client.api.post.return_value = {"id": 13}
+        src.server.create_project_config(21, "severity", "Critical", session_id=session_id)
+        mock_client.api.post.assert_called_once_with(
+            "/severities",
+            json={"project": 21, "name": "Critical", "color": "#999999"},
+        )
+
+    def test_create_project_config_issue_type(self, session_setup):
+        """Test create_project_config for issue_type."""
+        session_id, mock_client = session_setup
+        mock_client.api.post.return_value = {"id": 14}
+        src.server.create_project_config(21, "issue_type", "Security", session_id=session_id)
+        mock_client.api.post.assert_called_once_with(
+            "/issue-types",
+            json={"project": 21, "name": "Security", "color": "#999999"},
+        )
+
+    def test_create_project_config_epic_status(self, session_setup):
+        """Test create_project_config for epic_status."""
+        session_id, mock_client = session_setup
+        mock_client.api.post.return_value = {"id": 15}
+        src.server.create_project_config(21, "epic_status", "Backlog", session_id=session_id)
+        mock_client.api.post.assert_called_once_with(
+            "/epic-statuses",
+            json={"project": 21, "name": "Backlog", "color": "#999999"},
+        )
+
+    def test_create_project_config_empty_name_raises(self):
+        """Test create_project_config raises on empty name."""
+        with pytest.raises(ValueError, match="Name cannot be empty"):
+            src.server.create_project_config(21, "issue_status", "  ")
+
+    def test_create_project_config_invalid_type_raises(self):
+        """Test create_project_config raises on invalid config_type."""
+        with pytest.raises(ValueError, match="Invalid config_type"):
+            src.server.create_project_config(21, "bogus", "Name")
+
+    def test_create_project_config_user_story_status_alias(self, session_setup):
+        """Test user_story_status alias maps to userstory-statuses."""
+        session_id, mock_client = session_setup
+        mock_client.api.post.return_value = {"id": 16}
+        src.server.create_project_config(21, "user_story_status", "New", session_id=session_id)
+        assert mock_client.api.post.call_args[0][0] == "/userstory-statuses"
+
+    def test_update_project_config(self, session_setup):
+        """Test update_project_config calls correct endpoint."""
+        session_id, mock_client = session_setup
+        mock_client.api.patch.return_value = {"id": 10, "name": "Reviewed"}
+        result = src.server.update_project_config(
+            10, "issue_status", name="Reviewed", session_id=session_id
+        )
+        mock_client.api.patch.assert_called_once_with(
+            "/issue-statuses/10", json={"name": "Reviewed"}
+        )
+        assert result["name"] == "Reviewed"
+
+    def test_update_project_config_multiple_fields(self, session_setup):
+        """Test update_project_config with multiple fields."""
+        session_id, mock_client = session_setup
+        mock_client.api.patch.return_value = {"id": 10}
+        src.server.update_project_config(
+            10, "priority", name="Critical", color="#FF0000", order=1, session_id=session_id
+        )
+        call_json = mock_client.api.patch.call_args[1]["json"]
+        assert call_json["name"] == "Critical"
+        assert call_json["color"] == "#FF0000"
+        assert call_json["order"] == 1
+
+    def test_update_project_config_empty_name_raises(self):
+        """Test update_project_config raises on empty name."""
+        with pytest.raises(ValueError, match="Name cannot be empty"):
+            src.server.update_project_config(10, "issue_status", name="  ")
+
+    def test_update_project_config_no_fields_raises(self):
+        """Test update_project_config raises when no fields provided."""
+        with pytest.raises(ValueError, match="At least one field"):
+            src.server.update_project_config(10, "issue_status")
+
+    def test_update_project_config_invalid_type_raises(self):
+        """Test update_project_config raises on invalid config_type."""
+        with pytest.raises(ValueError, match="Invalid config_type"):
+            src.server.update_project_config(10, "bogus", name="X")
+
+    def test_delete_project_config(self, session_setup):
+        """Test delete_project_config calls correct endpoint."""
+        session_id, mock_client = session_setup
+        mock_client.api.delete.return_value = None
+        result = src.server.delete_project_config(10, "severity", session_id=session_id)
+        mock_client.api.delete.assert_called_once_with("/severities/10")
+        assert result["status"] == "deleted"
+        assert result["item_id"] == 10
+
+    def test_delete_project_config_invalid_type_raises(self):
+        """Test delete_project_config raises on invalid config_type."""
+        with pytest.raises(ValueError, match="Invalid config_type"):
+            src.server.delete_project_config(10, "bogus")
+
+    def test_bulk_update_order_project_config(self, session_setup):
+        """Test bulk_update_order_project_config calls correct endpoint."""
+        session_id, mock_client = session_setup
+        mock_client.api.post.return_value = None
+        result = src.server.bulk_update_order_project_config(
+            21, "issue_status", [[1, 1], [2, 2], [3, 3]], session_id=session_id
+        )
+        mock_client.api.post.assert_called_once_with(
+            "/issue-statuses/bulk_update_order",
+            json={"project": 21, "bulk_orders": [[1, 1], [2, 2], [3, 3]]},
+        )
+        assert result["status"] == "updated"
+        assert result["items_reordered"] == 3
+
+    def test_bulk_update_order_project_config_empty_raises(self):
+        """Test bulk_update_order_project_config raises on empty list."""
+        with pytest.raises(ValueError, match="bulk_orders cannot be empty"):
+            src.server.bulk_update_order_project_config(21, "priority", [])
+
+    def test_bulk_update_order_project_config_invalid_pair_raises(self):
+        """Test bulk_update_order_project_config raises on malformed pair."""
+        with pytest.raises(ValueError, match="must be a \\[id, order\\] pair"):
+            src.server.bulk_update_order_project_config(21, "priority", [[1]])
+
+    def test_bulk_update_order_project_config_invalid_type_raises(self):
+        """Test bulk_update_order_project_config raises on invalid config_type."""
+        with pytest.raises(ValueError, match="Invalid config_type"):
+            src.server.bulk_update_order_project_config(21, "bogus", [[1, 1]])
+
     # ─── Story Points tools tests ─────────────────────────────────────
 
     def test_list_points(self, session_setup):


### PR DESCRIPTION
## Summary
- Add 4 polymorphic tools for full CRUD on project configuration items (statuses, types, priorities, severities)
- `create_project_config`, `update_project_config`, `delete_project_config`, `bulk_update_order_project_config`
- Covers all 7 config types via `_PROJECT_CONFIG_TYPE_MAP` (4 tools instead of 28)
- Includes `user_story_status` alias support

## Test plan
- [x] 20 unit tests covering all 4 tools, all config types, aliases, validation
- [x] ruff lint + format passing
- [x] Full test suite: 270 tests passing (250 existing + 20 new)

Closes #25