### PR TITLE
feat: enrich user story responses with associated tasks

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -553,6 +553,8 @@ def _enrich_user_story_tasks(
     This helper fetches the actual tasks and injects them into the response.
 
     Task verbosity mapping: US standard → task minimal, US full → task standard.
+
+    Note: Mutates us_result in-place (sets the 'tasks' key) and returns it.
     """
     if verbosity == "minimal":
         return us_result
@@ -1096,9 +1098,22 @@ def get_user_story_by_ref(
 ) -> Dict[str, Any]:
     """Retrieves user story details by ref number within a project."""
     actual_session_id = _get_session_id(session_id)
-    result = _get_item_by_ref("user_story", "user_stories", project_id, ref, session_id, verbosity)
+    logger.info(
+        f"Executing get_user_story_by_ref ref #{ref} in project {project_id} "
+        f"for session {actual_session_id[:8]}..."
+    )
     taiga_client_wrapper = _get_authenticated_client(actual_session_id)
-    return _enrich_user_story_tasks(result, taiga_client_wrapper, verbosity)
+    api_collection = getattr(taiga_client_wrapper.api, "user_stories")
+
+    result = _execute_taiga_operation(
+        "get_user_story_by_ref",
+        lambda: api_collection.get_by_ref(ref=ref, project=project_id),
+        f"user story ref #{ref} in project {project_id}",
+    )
+    if not result:
+        raise ValueError(f"User story with ref #{ref} not found in project {project_id}")
+    filtered = _filter_response(result, "user_story", verbosity)
+    return _enrich_user_story_tasks(filtered, taiga_client_wrapper, verbosity)
 
 
 @mcp.tool(

--- a/src/server.py
+++ b/src/server.py
@@ -223,6 +223,7 @@ RESPONSE_FIELDS: Dict[str, Dict[str, Optional[List[str]]]] = {
             "is_closed",
             "due_date",
             "version",
+            "tasks",
         ],
         "full": None,
     },
@@ -539,6 +540,39 @@ def _filter_response(response, resource_type: str, verbosity: str = "standard"):
     if isinstance(response, list):
         return [filter_dict(item) for item in response]
     return filter_dict(response)
+
+
+def _enrich_user_story_tasks(
+    us_result: Dict[str, Any],
+    taiga_client_wrapper,
+    verbosity: str,
+) -> Dict[str, Any]:
+    """Enrich a user story response with its associated tasks.
+
+    The Taiga API returns an empty tasks array in user story detail responses.
+    This helper fetches the actual tasks and injects them into the response.
+
+    Task verbosity mapping: US standard → task minimal, US full → task standard.
+    """
+    if verbosity == "minimal":
+        return us_result
+
+    us_id = us_result.get("id")
+    project_id = us_result.get("project")
+    if not us_id or not project_id:
+        return us_result
+
+    task_verbosity = "minimal" if verbosity == "standard" else "standard"
+    try:
+        tasks = taiga_client_wrapper.list_resources(
+            "tasks", project_id=project_id, user_story=us_id
+        )
+        us_result["tasks"] = _filter_response(tasks, "task", task_verbosity)
+    except Exception as e:
+        logger.warning(f"Failed to fetch tasks for user story {us_id}: {e}")
+        us_result["tasks"] = []
+
+    return us_result
 
 
 def _get_item_by_ref(
@@ -1049,7 +1083,8 @@ def get_user_story(
         lambda: taiga_client_wrapper.api.user_stories.get(user_story_id),
         f"user story {user_story_id}",
     )
-    return _filter_response(result, "user_story", verbosity)
+    filtered = _filter_response(result, "user_story", verbosity)
+    return _enrich_user_story_tasks(filtered, taiga_client_wrapper, verbosity)
 
 
 @mcp.tool(
@@ -1060,7 +1095,10 @@ def get_user_story_by_ref(
     project_id: int, ref: int, session_id: Optional[str] = None, verbosity: str = "standard"
 ) -> Dict[str, Any]:
     """Retrieves user story details by ref number within a project."""
-    return _get_item_by_ref("user_story", "user_stories", project_id, ref, session_id, verbosity)
+    actual_session_id = _get_session_id(session_id)
+    result = _get_item_by_ref("user_story", "user_stories", project_id, ref, session_id, verbosity)
+    taiga_client_wrapper = _get_authenticated_client(actual_session_id)
+    return _enrich_user_story_tasks(result, taiga_client_wrapper, verbosity)
 
 
 @mcp.tool(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2517,6 +2517,143 @@ class TestResponseFiltering:
         assert "watchers" not in result
 
 
+# ─── User Story Task Enrichment tests ────────────────────────────────
+
+
+class TestEnrichUserStoryTasks:
+    """Tests for the _enrich_user_story_tasks helper."""
+
+    def _make_us_result(self, us_id=606, project_id=21):
+        return {"id": us_id, "ref": 18, "subject": "Test US", "project": project_id, "tasks": []}
+
+    def _make_mock_client(self, tasks=None):
+        mock = MagicMock()
+        mock.list_resources.return_value = tasks or []
+        return mock
+
+    def test_standard_verbosity_includes_tasks_at_minimal_level(self):
+        """Standard verbosity should enrich with tasks filtered to minimal."""
+        raw_tasks = [
+            {
+                "id": 100,
+                "ref": 10,
+                "subject": "Task 1",
+                "status": 1,
+                "project": 21,
+                "description": "should be filtered",
+                "version": 1,
+            },
+            {
+                "id": 101,
+                "ref": 11,
+                "subject": "Task 2",
+                "status": 2,
+                "project": 21,
+                "description": "should be filtered",
+                "version": 1,
+            },
+        ]
+        mock_client = self._make_mock_client(raw_tasks)
+        us_result = self._make_us_result()
+
+        result = src.server._enrich_user_story_tasks(us_result, mock_client, "standard")
+
+        assert len(result["tasks"]) == 2
+        assert result["tasks"][0] == {
+            "id": 100,
+            "ref": 10,
+            "subject": "Task 1",
+            "status": 1,
+            "project": 21,
+        }
+        # description should be filtered out at minimal level
+        assert "description" not in result["tasks"][0]
+        mock_client.list_resources.assert_called_once_with("tasks", project_id=21, user_story=606)
+
+    def test_full_verbosity_includes_tasks_at_standard_level(self):
+        """Full verbosity should enrich with tasks filtered to standard."""
+        raw_tasks = [
+            {
+                "id": 100,
+                "ref": 10,
+                "subject": "Task 1",
+                "status": 1,
+                "status_extra_info": {"name": "New"},
+                "assigned_to": 9,
+                "assigned_to_extra_info": {"username": "user1"},
+                "user_story": 606,
+                "milestone": 1,
+                "project": 21,
+                "description": "A task",
+                "tags": [],
+                "is_blocked": False,
+                "due_date": None,
+                "version": 1,
+                "watchers": [1],
+            },
+        ]
+        mock_client = self._make_mock_client(raw_tasks)
+        us_result = self._make_us_result()
+
+        result = src.server._enrich_user_story_tasks(us_result, mock_client, "full")
+
+        assert len(result["tasks"]) == 1
+        assert "description" in result["tasks"][0]
+        assert "status_extra_info" in result["tasks"][0]
+        assert "assigned_to" in result["tasks"][0]
+        # watchers should be filtered out at standard level
+        assert "watchers" not in result["tasks"][0]
+
+    def test_minimal_verbosity_skips_enrichment(self):
+        """Minimal verbosity should not fetch tasks at all."""
+        mock_client = self._make_mock_client()
+        us_result = self._make_us_result()
+
+        result = src.server._enrich_user_story_tasks(us_result, mock_client, "minimal")
+
+        assert result["tasks"] == []
+        mock_client.list_resources.assert_not_called()
+
+    def test_graceful_fallback_on_fetch_failure(self):
+        """Should return empty tasks list if fetch fails."""
+        mock_client = MagicMock()
+        mock_client.list_resources.side_effect = Exception("Connection refused")
+        us_result = self._make_us_result()
+
+        result = src.server._enrich_user_story_tasks(us_result, mock_client, "standard")
+
+        assert result["tasks"] == []
+
+    def test_missing_id_skips_enrichment(self):
+        """Should skip enrichment if US result has no id."""
+        mock_client = self._make_mock_client()
+        us_result = {"ref": 18, "subject": "Test", "project": 21}
+
+        result = src.server._enrich_user_story_tasks(us_result, mock_client, "standard")
+
+        assert "tasks" not in result
+        mock_client.list_resources.assert_not_called()
+
+    def test_missing_project_skips_enrichment(self):
+        """Should skip enrichment if US result has no project."""
+        mock_client = self._make_mock_client()
+        us_result = {"id": 606, "ref": 18, "subject": "Test"}
+
+        result = src.server._enrich_user_story_tasks(us_result, mock_client, "standard")
+
+        assert "tasks" not in result
+        mock_client.list_resources.assert_not_called()
+
+    def test_mutates_input_dict(self):
+        """Should mutate the input dict in-place (documented behavior)."""
+        mock_client = self._make_mock_client([])
+        us_result = self._make_us_result()
+
+        result = src.server._enrich_user_story_tasks(us_result, mock_client, "standard")
+
+        assert result is us_result
+
+
 # ─── Config tests ─────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary
- The Taiga API returns an empty `tasks` array in user story detail endpoints
- Added `_enrich_user_story_tasks()` helper that auto-fetches tasks via `list_resources("tasks", user_story=id)` and injects them into the response
- Applied to both `get_user_story` and `get_user_story_by_ref`
- Task verbosity mapping: US `standard` → task `minimal`, US `full` → task `standard`, US `minimal` → no tasks

## Test plan
- [x] All 270 unit tests pass
- [x] Ruff lint + format pass
- [ ] Live test: `get_user_story_by_ref(project_id=21, ref=18)` should return 4 tasks (after MCP server restart)
- [ ] Verify `verbosity=minimal` does NOT include tasks
- [ ] Verify `verbosity=full` includes tasks with standard-level detail