### PR TITLE
fix: comment edit/delete 404 and literal \n in comment text

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -3175,8 +3175,8 @@ def add_comment(
         )
     if not comment or not comment.strip():
         raise ValueError("Comment text must not be empty.")
-    # Unescape literal \n sequences that LLMs send through MCP JSON
-    comment = comment.replace("\\n", "\n")
+    # Unescape literal escape sequences that LLMs send through MCP JSON
+    comment = comment.replace("\\n", "\n").replace("\\t", "\t")
 
     patch_path, _ = _COMMENT_TYPE_MAP[object_type]
     actual_session_id = _get_session_id(session_id)
@@ -3271,8 +3271,8 @@ def edit_comment(
             f"Must be one of: {', '.join(sorted(_COMMENT_TYPE_MAP.keys()))}"
         )
     new_comment = new_comment.strip() if new_comment else ""
-    # Unescape literal \n sequences that LLMs send through MCP JSON
-    new_comment = new_comment.replace("\\n", "\n")
+    # Unescape literal escape sequences that LLMs send through MCP JSON
+    new_comment = new_comment.replace("\\n", "\n").replace("\\t", "\t")
     if not new_comment:
         raise ValueError("New comment text must not be empty.")
     if not comment_id or not comment_id.strip():
@@ -3425,7 +3425,7 @@ def get_comment_versions(
 
     def do_get_versions():
         result = taiga_client_wrapper.api.get(
-            f"/history/{history_path}/{object_id}/comment_versions/{comment_id}"
+            f"/history/{history_path}/{object_id}/comment_versions/{comment_id}/"
         )
         return {
             "object_type": object_type,

--- a/src/server.py
+++ b/src/server.py
@@ -3175,6 +3175,8 @@ def add_comment(
         )
     if not comment or not comment.strip():
         raise ValueError("Comment text must not be empty.")
+    # Unescape literal \n sequences that LLMs send through MCP JSON
+    comment = comment.replace("\\n", "\n")
 
     patch_path, _ = _COMMENT_TYPE_MAP[object_type]
     actual_session_id = _get_session_id(session_id)
@@ -3269,6 +3271,8 @@ def edit_comment(
             f"Must be one of: {', '.join(sorted(_COMMENT_TYPE_MAP.keys()))}"
         )
     new_comment = new_comment.strip() if new_comment else ""
+    # Unescape literal \n sequences that LLMs send through MCP JSON
+    new_comment = new_comment.replace("\\n", "\n")
     if not new_comment:
         raise ValueError("New comment text must not be empty.")
     if not comment_id or not comment_id.strip():
@@ -3280,7 +3284,7 @@ def edit_comment(
 
     def do_edit():
         taiga_client_wrapper.api.post(
-            f"/history/{history_path}/{object_id}/edit_comment",
+            f"/history/{history_path}/{object_id}/edit_comment/",
             json={"comment_id": comment_id, "comment": new_comment},
         )
         return {
@@ -3327,7 +3331,7 @@ def delete_comment(
 
     def do_delete():
         taiga_client_wrapper.api.post(
-            f"/history/{history_path}/{object_id}/delete_comment",
+            f"/history/{history_path}/{object_id}/delete_comment/",
             json={"comment_id": comment_id},
         )
         return {
@@ -3374,7 +3378,7 @@ def undelete_comment(
 
     def do_undelete():
         taiga_client_wrapper.api.post(
-            f"/history/{history_path}/{object_id}/undelete_comment",
+            f"/history/{history_path}/{object_id}/undelete_comment/",
             json={"comment_id": comment_id},
         )
         return {

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1866,6 +1866,30 @@ class TestTaigaTools:
         with pytest.raises(ValueError, match="Invalid object_type"):
             src.server.add_comment(1, "invalid_type", "comment", session_id)
 
+    def test_add_comment_unescapes_newlines(self, session_setup):
+        """Test add_comment converts literal \\n to actual newlines."""
+        session_id, mock_client = session_setup
+        mock_client.api.get.return_value = {"id": 42, "version": 3}
+        mock_client.api.patch.return_value = {"id": 42, "version": 4}
+
+        src.server.add_comment(42, "issue", "Line 1\\nLine 2\\nLine 3", session_id)
+
+        mock_client.api.patch.assert_called_once_with(
+            "/issues/42", json={"comment": "Line 1\nLine 2\nLine 3", "version": 3}
+        )
+
+    def test_edit_comment_unescapes_newlines(self, session_setup):
+        """Test edit_comment converts literal \\n to actual newlines."""
+        session_id, mock_client = session_setup
+        mock_client.api.post.return_value = None
+
+        src.server.edit_comment(42, "issue", "abc", "Line 1\\nLine 2", session_id)
+
+        mock_client.api.post.assert_called_once_with(
+            "/history/issue/42/edit_comment/",
+            json={"comment_id": "abc", "comment": "Line 1\nLine 2"},
+        )
+
     def test_add_comment_missing_version(self, session_setup):
         """Test add_comment raises ValueError when object has no version field."""
         session_id, mock_client = session_setup
@@ -1958,7 +1982,7 @@ class TestTaigaTools:
         result = src.server.edit_comment(42, "issue", "abc123", "Updated text", session_id)
 
         mock_client.api.post.assert_called_once_with(
-            "/history/issue/42/edit_comment",
+            "/history/issue/42/edit_comment/",
             json={"comment_id": "abc123", "comment": "Updated text"},
         )
         assert result["status"] == "comment_edited"
@@ -1972,7 +1996,7 @@ class TestTaigaTools:
         src.server.edit_comment(42, "task", "abc", "  trimmed  ", session_id)
 
         mock_client.api.post.assert_called_once_with(
-            "/history/task/42/edit_comment",
+            "/history/task/42/edit_comment/",
             json={"comment_id": "abc", "comment": "trimmed"},
         )
 
@@ -1996,7 +2020,7 @@ class TestTaigaTools:
         result = src.server.delete_comment(42, "user_story", "abc123", session_id)
 
         mock_client.api.post.assert_called_once_with(
-            "/history/userstory/42/delete_comment",
+            "/history/userstory/42/delete_comment/",
             json={"comment_id": "abc123"},
         )
         assert result["status"] == "comment_deleted"
@@ -2016,7 +2040,7 @@ class TestTaigaTools:
         result = src.server.undelete_comment(42, "epic", "abc123", session_id)
 
         mock_client.api.post.assert_called_once_with(
-            "/history/epic/42/undelete_comment",
+            "/history/epic/42/undelete_comment/",
             json={"comment_id": "abc123"},
         )
         assert result["status"] == "comment_restored"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1866,28 +1866,28 @@ class TestTaigaTools:
         with pytest.raises(ValueError, match="Invalid object_type"):
             src.server.add_comment(1, "invalid_type", "comment", session_id)
 
-    def test_add_comment_unescapes_newlines(self, session_setup):
-        """Test add_comment converts literal \\n to actual newlines."""
+    def test_add_comment_unescapes_newlines_and_tabs(self, session_setup):
+        """Test add_comment converts literal \\n and \\t to actual characters."""
         session_id, mock_client = session_setup
         mock_client.api.get.return_value = {"id": 42, "version": 3}
         mock_client.api.patch.return_value = {"id": 42, "version": 4}
 
-        src.server.add_comment(42, "issue", "Line 1\\nLine 2\\nLine 3", session_id)
+        src.server.add_comment(42, "issue", "Line 1\\nLine 2\\tindented", session_id)
 
         mock_client.api.patch.assert_called_once_with(
-            "/issues/42", json={"comment": "Line 1\nLine 2\nLine 3", "version": 3}
+            "/issues/42", json={"comment": "Line 1\nLine 2\tindented", "version": 3}
         )
 
-    def test_edit_comment_unescapes_newlines(self, session_setup):
-        """Test edit_comment converts literal \\n to actual newlines."""
+    def test_edit_comment_unescapes_newlines_and_tabs(self, session_setup):
+        """Test edit_comment converts literal \\n and \\t to actual characters."""
         session_id, mock_client = session_setup
         mock_client.api.post.return_value = None
 
-        src.server.edit_comment(42, "issue", "abc", "Line 1\\nLine 2", session_id)
+        src.server.edit_comment(42, "issue", "abc", "Line 1\\nLine 2\\tindented", session_id)
 
         mock_client.api.post.assert_called_once_with(
             "/history/issue/42/edit_comment/",
-            json={"comment_id": "abc", "comment": "Line 1\nLine 2"},
+            json={"comment_id": "abc", "comment": "Line 1\nLine 2\tindented"},
         )
 
     def test_add_comment_missing_version(self, session_setup):
@@ -2062,7 +2062,7 @@ class TestTaigaTools:
 
         result = src.server.get_comment_versions(42, "task", "abc123", session_id)
 
-        mock_client.api.get.assert_called_once_with("/history/task/42/comment_versions/abc123")
+        mock_client.api.get.assert_called_once_with("/history/task/42/comment_versions/abc123/")
         assert result["comment_id"] == "abc123"
         assert len(result["versions"]) == 2
 


### PR DESCRIPTION
## Summary
- **#44**: `edit_comment`, `delete_comment`, `undelete_comment` returned 404 for all object types. Root cause: history POST endpoints missing trailing slashes — Django's `APPEND_SLASH` sends a 301 redirect, but `requests` library converts POST→GET on 301, losing the request body and hitting a non-existent GET endpoint.
- **#45**: `add_comment` stored newlines as literal `\n` text instead of actual line breaks. Root cause: LLMs send literal `\n` escape sequences through MCP JSON. Added unescape of `\\n`→`\n` in `add_comment` and `edit_comment`.

## Changes
- Added trailing slashes to all history POST paths (`edit_comment/`, `delete_comment/`, `undelete_comment/`)
- Added `comment.replace("\\n", "\n")` in `add_comment` and `edit_comment`
- Updated 4 existing tests for trailing slash change
- Added 2 new tests for newline unescape behavior

## Test plan
- [x] 279 unit tests pass (4 updated + 2 new)
- [x] Ruff lint + format pass
- [ ] Live test: `edit_comment` on a user story comment
- [ ] Live test: `add_comment` with multi-line markdown text

Closes #44, closes #45