### PR TITLE
fix: document kwargs JSON pattern and raise on empty-kwargs updates

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -484,7 +484,11 @@ def _execute_taiga_operation(operation_name: str, operation_callable, error_cont
 
     Raises:
         TaigaException: Re-raised from the API
-        RuntimeError: Wrapped unexpected errors
+        ValueError: Re-raised unwrapped from the operation callable (caller bugs:
+            empty kwargs, missing required fields, ref-not-found, etc.) so callers
+            see the original message rather than a generic "Server error" wrapper.
+        RuntimeError: Wrapped unexpected errors (anything not TaigaException or
+            ValueError)
     """
     context_str = f" for {error_context}" if error_context else ""
     try:

--- a/src/server.py
+++ b/src/server.py
@@ -698,9 +698,6 @@ def login(
         logger.error(f"Login failed: {e}", exc_info=False)
         # Re-raise the exception - FastMCP will turn it into an error response
         raise e
-    except ValueError:
-        # Caller-bug ValueErrors (e.g. empty kwargs) propagate without being wrapped.
-        raise
     except Exception as e:
         logger.error(f"Unexpected error during login: {e}", exc_info=True)
         raise RuntimeError("An unexpected server error occurred during login.")
@@ -3063,10 +3060,11 @@ def get_wiki_page(
 @mcp.tool(
     "create_wiki_page",
     description=(
-        "Creates a new wiki page. Optional fields (e.g. watchers) must be passed as a JSON "
-        "object via the `kwargs` parameter, NOT as top-level arguments — top-level args other "
-        "than the declared signature params are silently dropped by FastMCP. Allowed keys: see "
-        "ALLOWED_KWARGS['wiki_page'] in server.py. verbosity: 'minimal', 'standard' (default), "
+        "Creates a new wiki page. Required fields (project_id, slug, content) are top-level "
+        "params. The `kwargs` parameter accepts only the keys in ALLOWED_KWARGS['wiki_page'] "
+        "(currently `slug` and `content`, useful for overriding the positional values via JSON); "
+        "any other key is silently dropped by FastMCP if passed at the top level, or stripped by "
+        "_validate_kwargs if passed inside kwargs. verbosity: 'minimal', 'standard' (default), "
         "'full'. Uses default session if session_id not provided."
     ),
 )
@@ -3126,9 +3124,10 @@ def get_wiki_page_by_slug(
     "update_wiki_page",
     description=(
         "Updates an existing wiki page. Pass fields to update as a JSON object via the "
-        "`kwargs` parameter, NOT as top-level arguments — top-level args other than the "
-        "declared signature params are silently dropped by FastMCP. Calling with empty `kwargs` "
-        "raises ValueError. Allowed keys: see ALLOWED_KWARGS['wiki_page'] in server.py. "
+        "`kwargs` parameter (allowed keys for wiki pages: `slug`, `content`), NOT as top-level "
+        "arguments — top-level args other than the declared signature params are silently "
+        "dropped by FastMCP. Calling with empty `kwargs` raises ValueError. See "
+        "ALLOWED_KWARGS['wiki_page'] in server.py for the authoritative list. "
         "verbosity: 'minimal', 'standard' (default), 'full'. Uses default session if session_id not provided."
     ),
 )

--- a/src/server.py
+++ b/src/server.py
@@ -493,6 +493,9 @@ def _execute_taiga_operation(operation_name: str, operation_callable, error_cont
     except TaigaException as e:
         logger.error(f"Taiga API error in {operation_name}{context_str}: {e}", exc_info=False)
         raise e
+    except ValueError:
+        # Caller-bug ValueErrors (e.g. empty kwargs) propagate without being wrapped.
+        raise
     except Exception as e:
         logger.error(f"Unexpected error in {operation_name}{context_str}: {e}", exc_info=True)
         raise RuntimeError(f"Server error in {operation_name}: {e}")
@@ -695,6 +698,9 @@ def login(
         logger.error(f"Login failed: {e}", exc_info=False)
         # Re-raise the exception - FastMCP will turn it into an error response
         raise e
+    except ValueError:
+        # Caller-bug ValueErrors (e.g. empty kwargs) propagate without being wrapped.
+        raise
     except Exception as e:
         logger.error(f"Unexpected error during login: {e}", exc_info=True)
         raise RuntimeError("An unexpected server error occurred during login.")
@@ -776,7 +782,13 @@ def get_project_by_slug(
 
 @mcp.tool(
     "create_project",
-    description="Creates a new project. verbosity: 'minimal', 'standard' (default), 'full'. Uses default session if session_id not provided.",
+    description=(
+        "Creates a new project. Optional fields (e.g. is_private, tags, is_kanban_activated, "
+        "is_issues_activated) must be passed as a JSON object via the `kwargs` parameter, NOT "
+        "as top-level arguments — top-level args other than the declared signature params are "
+        "silently dropped by FastMCP. Allowed keys: see ALLOWED_KWARGS['project'] in server.py. "
+        "verbosity: 'minimal', 'standard' (default), 'full'. Uses default session if session_id not provided."
+    ),
 )
 def create_project(
     name: str,
@@ -807,7 +819,13 @@ def create_project(
 
 @mcp.tool(
     "update_project",
-    description="Updates details of an existing project. verbosity: 'minimal', 'standard' (default), 'full'. Uses default session if session_id not provided.",
+    description=(
+        "Updates details of an existing project. Pass fields to update as a JSON object via "
+        "the `kwargs` parameter, NOT as top-level arguments — top-level args other than the "
+        "declared signature params are silently dropped by FastMCP. Calling with empty `kwargs` "
+        "raises ValueError. Allowed keys: see ALLOWED_KWARGS['project'] in server.py. "
+        "verbosity: 'minimal', 'standard' (default), 'full'. Uses default session if session_id not provided."
+    ),
 )
 def update_project(
     project_id: int,
@@ -825,10 +843,11 @@ def update_project(
     try:
         # Use pytaigaclient update pattern: client.resource.update(id=..., data=...)
         if not parsed_kwargs:
-            logger.info(f"No fields provided for update on project {project_id}")
-            # Return current state if no updates provided
-            result = taiga_client_wrapper.api.projects.get(project_id=project_id)
-            return _filter_response(result, "project", verbosity)
+            raise ValueError(
+                f"update_project called with no fields to update for project {project_id}. "
+                'Pass fields inside the `kwargs` JSON object (e.g. kwargs={"name": "..."}), '
+                "not as top-level arguments."
+            )
 
         # First fetch the project to get its current version
         current_project = taiga_client_wrapper.api.projects.get(project_id=project_id)
@@ -850,6 +869,9 @@ def update_project(
     except TaigaException as e:
         logger.error(f"Taiga API error updating project {project_id}: {e}", exc_info=False)
         raise e
+    except ValueError:
+        # Caller-bug ValueErrors (e.g. empty kwargs) propagate without being wrapped.
+        raise
     except Exception as e:
         logger.error(f"Unexpected error updating project {project_id}: {e}", exc_info=True)
         raise RuntimeError(f"Server error updating project: {e}")
@@ -1037,7 +1059,14 @@ def list_user_stories(
 
 @mcp.tool(
     "create_user_story",
-    description="Creates a new user story within a project. verbosity: 'minimal', 'standard' (default), 'full'. Uses default session if session_id not provided.",
+    description=(
+        "Creates a new user story within a project. Optional fields (e.g. description, tags, "
+        "status, milestone, assigned_to, points) must be passed as a JSON object via the "
+        "`kwargs` parameter, NOT as top-level arguments — top-level args other than the "
+        "declared signature params are silently dropped by FastMCP. Allowed keys: see "
+        "ALLOWED_KWARGS['user_story'] in server.py. verbosity: 'minimal', 'standard' (default), "
+        "'full'. Uses default session if session_id not provided."
+    ),
 )
 def create_user_story(
     project_id: int,
@@ -1118,7 +1147,16 @@ def get_user_story_by_ref(
 
 @mcp.tool(
     "update_user_story",
-    description="Updates details of an existing user story. verbosity: 'minimal', 'standard' (default), 'full'. Note: embedded tasks use one verbosity level lower (standard→task minimal with raw status IDs only, full→task standard with status_extra_info). Uses default session if session_id not provided.",
+    description=(
+        "Updates details of an existing user story. Pass fields to update as a JSON object via "
+        'the `kwargs` parameter (e.g. kwargs={"description": "...", "tags": [...], '
+        '"status": 2}), NOT as top-level arguments — top-level args other than the declared '
+        "signature params are silently dropped by FastMCP. Calling with empty `kwargs` raises "
+        "ValueError. Allowed keys: see ALLOWED_KWARGS['user_story'] in server.py. "
+        "verbosity: 'minimal', 'standard' (default), 'full'. Note: embedded tasks use one "
+        "verbosity level lower (standard→task minimal with raw status IDs only, full→task "
+        "standard with status_extra_info). Uses default session if session_id not provided."
+    ),
 )
 def update_user_story(
     user_story_id: int,
@@ -1135,9 +1173,11 @@ def update_user_story(
     taiga_client_wrapper = _get_authenticated_client(actual_session_id)
     try:
         if not parsed_kwargs:
-            logger.info(f"No fields provided for update on user story {user_story_id}")
-            result = taiga_client_wrapper.api.user_stories.get(user_story_id)
-            return _filter_response(result, "user_story", verbosity)
+            raise ValueError(
+                f"update_user_story called with no fields to update for user story {user_story_id}. "
+                "Pass fields inside the `kwargs` JSON object "
+                '(e.g. kwargs={"description": "...", "tags": [...]}), not as top-level arguments.'
+            )
 
         # Get current user story data to retrieve version
         current_story = taiga_client_wrapper.api.user_stories.get(user_story_id)
@@ -1156,6 +1196,9 @@ def update_user_story(
     except TaigaException as e:
         logger.error(f"Taiga API error updating user story {user_story_id}: {e}", exc_info=False)
         raise e
+    except ValueError:
+        # Caller-bug ValueErrors (e.g. empty kwargs) propagate without being wrapped.
+        raise
     except Exception as e:
         logger.error(f"Unexpected error updating user story {user_story_id}: {e}", exc_info=True)
         raise RuntimeError(f"Server error updating user story: {e}")
@@ -1266,7 +1309,14 @@ def list_tasks(
 
 @mcp.tool(
     "create_task",
-    description="Creates a new task within a project. verbosity: 'minimal', 'standard' (default), 'full'. Uses default session if session_id not provided.",
+    description=(
+        "Creates a new task within a project. Optional fields (e.g. description, tags, status, "
+        "milestone, user_story, assigned_to) must be passed as a JSON object via the `kwargs` "
+        "parameter, NOT as top-level arguments — top-level args other than the declared "
+        "signature params are silently dropped by FastMCP. Allowed keys: see "
+        "ALLOWED_KWARGS['task'] in server.py. verbosity: 'minimal', 'standard' (default), "
+        "'full'. Uses default session if session_id not provided."
+    ),
 )
 def create_task(
     project_id: int,
@@ -1343,7 +1393,13 @@ def get_task_by_ref(
 
 @mcp.tool(
     "update_task",
-    description="Updates details of an existing task. verbosity: 'minimal', 'standard' (default), 'full'. Uses default session if session_id not provided.",
+    description=(
+        "Updates details of an existing task. Pass fields to update as a JSON object via the "
+        "`kwargs` parameter, NOT as top-level arguments — top-level args other than the "
+        "declared signature params are silently dropped by FastMCP. Calling with empty `kwargs` "
+        "raises ValueError. Allowed keys: see ALLOWED_KWARGS['task'] in server.py. "
+        "verbosity: 'minimal', 'standard' (default), 'full'. Uses default session if session_id not provided."
+    ),
 )
 def update_task(
     task_id: int, kwargs: Any = None, session_id: Optional[str] = None, verbosity: str = "standard"
@@ -1358,9 +1414,10 @@ def update_task(
     try:
         # Use pytaigaclient edit pattern for partial updates
         if not parsed_kwargs:
-            logger.info(f"No fields provided for update on task {task_id}")
-            result = taiga_client_wrapper.api.tasks.get(task_id)
-            return _filter_response(result, "task", verbosity)
+            raise ValueError(
+                f"update_task called with no fields to update for task {task_id}. "
+                "Pass fields inside the `kwargs` JSON object, not as top-level arguments."
+            )
 
         # Get current task data to retrieve version
         current_task = taiga_client_wrapper.api.tasks.get(task_id)
@@ -1377,6 +1434,9 @@ def update_task(
     except TaigaException as e:
         logger.error(f"Taiga API error updating task {task_id}: {e}", exc_info=False)
         raise e
+    except ValueError:
+        # Caller-bug ValueErrors (e.g. empty kwargs) propagate without being wrapped.
+        raise
     except Exception as e:
         logger.error(f"Unexpected error updating task {task_id}: {e}", exc_info=True)
         raise RuntimeError(f"Server error updating task: {e}")
@@ -1481,7 +1541,14 @@ def list_issues(
 
 @mcp.tool(
     "create_issue",
-    description="Creates a new issue within a project. verbosity: 'minimal', 'standard' (default), 'full'. Uses default session if session_id not provided.",
+    description=(
+        "Creates a new issue within a project. Optional fields (e.g. description, tags, "
+        "milestone, assigned_to) must be passed as a JSON object via the `kwargs` parameter, "
+        "NOT as top-level arguments — top-level args other than the declared signature params "
+        "are silently dropped by FastMCP. Required fields (priority_id, status_id, severity_id, "
+        "type_id) remain top-level. Allowed kwargs keys: see ALLOWED_KWARGS['issue'] in server.py. "
+        "verbosity: 'minimal', 'standard' (default), 'full'. Uses default session if session_id not provided."
+    ),
 )
 def create_issue(
     project_id: int,
@@ -1555,7 +1622,13 @@ def get_issue_by_ref(
 
 @mcp.tool(
     "update_issue",
-    description="Updates details of an existing issue. verbosity: 'minimal', 'standard' (default), 'full'. Uses default session if session_id not provided.",
+    description=(
+        "Updates details of an existing issue. Pass fields to update as a JSON object via the "
+        "`kwargs` parameter, NOT as top-level arguments — top-level args other than the "
+        "declared signature params are silently dropped by FastMCP. Calling with empty `kwargs` "
+        "raises ValueError. Allowed keys: see ALLOWED_KWARGS['issue'] in server.py. "
+        "verbosity: 'minimal', 'standard' (default), 'full'. Uses default session if session_id not provided."
+    ),
 )
 def update_issue(
     issue_id: int, kwargs: Any = None, session_id: Optional[str] = None, verbosity: str = "standard"
@@ -1570,9 +1643,10 @@ def update_issue(
     try:
         # Use pytaigaclient edit pattern for partial updates
         if not parsed_kwargs:
-            logger.info(f"No fields provided for update on issue {issue_id}")
-            result = taiga_client_wrapper.api.issues.get(issue_id)
-            return _filter_response(result, "issue", verbosity)
+            raise ValueError(
+                f"update_issue called with no fields to update for issue {issue_id}. "
+                "Pass fields inside the `kwargs` JSON object, not as top-level arguments."
+            )
 
         # Get current issue data to retrieve version
         current_issue = taiga_client_wrapper.api.issues.get(issue_id)
@@ -1589,6 +1663,9 @@ def update_issue(
     except TaigaException as e:
         logger.error(f"Taiga API error updating issue {issue_id}: {e}", exc_info=False)
         raise e
+    except ValueError:
+        # Caller-bug ValueErrors (e.g. empty kwargs) propagate without being wrapped.
+        raise
     except Exception as e:
         logger.error(f"Unexpected error updating issue {issue_id}: {e}", exc_info=True)
         raise RuntimeError(f"Server error updating issue: {e}")
@@ -2534,7 +2611,13 @@ def list_epics(
 
 @mcp.tool(
     "create_epic",
-    description="Creates a new epic within a project. verbosity: 'minimal', 'standard' (default), 'full'. Uses default session if session_id not provided.",
+    description=(
+        "Creates a new epic within a project. Optional fields (e.g. description, tags, color, "
+        "status, assigned_to) must be passed as a JSON object via the `kwargs` parameter, NOT "
+        "as top-level arguments — top-level args other than the declared signature params are "
+        "silently dropped by FastMCP. Allowed keys: see ALLOWED_KWARGS['epic'] in server.py. "
+        "verbosity: 'minimal', 'standard' (default), 'full'. Uses default session if session_id not provided."
+    ),
 )
 def create_epic(
     project_id: int,
@@ -2594,7 +2677,13 @@ def get_epic_by_ref(
 
 @mcp.tool(
     "update_epic",
-    description="Updates details of an existing epic. verbosity: 'minimal', 'standard' (default), 'full'. Uses default session if session_id not provided.",
+    description=(
+        "Updates details of an existing epic. Pass fields to update as a JSON object via the "
+        "`kwargs` parameter, NOT as top-level arguments — top-level args other than the "
+        "declared signature params are silently dropped by FastMCP. Calling with empty `kwargs` "
+        "raises ValueError. Allowed keys: see ALLOWED_KWARGS['epic'] in server.py. "
+        "verbosity: 'minimal', 'standard' (default), 'full'. Uses default session if session_id not provided."
+    ),
 )
 def update_epic(
     epic_id: int, kwargs: Any = None, session_id: Optional[str] = None, verbosity: str = "standard"
@@ -2608,9 +2697,10 @@ def update_epic(
     taiga_client_wrapper = _get_authenticated_client(actual_session_id)
     try:
         if not parsed_kwargs:
-            logger.info(f"No fields provided for update on epic {epic_id}")
-            result = taiga_client_wrapper.api.epics.get(epic_id)
-            return _filter_response(result, "epic", verbosity)
+            raise ValueError(
+                f"update_epic called with no fields to update for epic {epic_id}. "
+                "Pass fields inside the `kwargs` JSON object, not as top-level arguments."
+            )
 
         # Get current epic data to retrieve version
         current_epic = taiga_client_wrapper.api.epics.get(epic_id)
@@ -2627,6 +2717,9 @@ def update_epic(
     except TaigaException as e:
         logger.error(f"Taiga API error updating epic {epic_id}: {e}", exc_info=False)
         raise e
+    except ValueError:
+        # Caller-bug ValueErrors (e.g. empty kwargs) propagate without being wrapped.
+        raise
     except Exception as e:
         logger.error(f"Unexpected error updating epic {epic_id}: {e}", exc_info=True)
         raise RuntimeError(f"Server error updating epic: {e}")
@@ -2794,7 +2887,13 @@ def get_milestone(
 
 @mcp.tool(
     "update_milestone",
-    description="Updates details of an existing milestone. verbosity: 'minimal', 'standard' (default), 'full'. Uses default session if session_id not provided.",
+    description=(
+        "Updates details of an existing milestone. Pass fields to update as a JSON object via "
+        "the `kwargs` parameter, NOT as top-level arguments — top-level args other than the "
+        "declared signature params are silently dropped by FastMCP. Calling with empty `kwargs` "
+        "raises ValueError. Allowed keys: see ALLOWED_KWARGS['milestone'] in server.py. "
+        "verbosity: 'minimal', 'standard' (default), 'full'. Uses default session if session_id not provided."
+    ),
 )
 def update_milestone(
     milestone_id: int,
@@ -2811,9 +2910,10 @@ def update_milestone(
     taiga_client_wrapper = _get_authenticated_client(actual_session_id)
     try:
         if not parsed_kwargs:
-            logger.info(f"No fields provided for update on milestone {milestone_id}")
-            result = taiga_client_wrapper.api.milestones.get(milestone_id)
-            return _filter_response(result, "milestone", verbosity)
+            raise ValueError(
+                f"update_milestone called with no fields to update for milestone {milestone_id}. "
+                "Pass fields inside the `kwargs` JSON object, not as top-level arguments."
+            )
 
         # Get current milestone data to retrieve version
         current_milestone = taiga_client_wrapper.api.milestones.get(milestone_id)
@@ -2832,6 +2932,9 @@ def update_milestone(
     except TaigaException as e:
         logger.error(f"Taiga API error updating milestone {milestone_id}: {e}", exc_info=False)
         raise e
+    except ValueError:
+        # Caller-bug ValueErrors (e.g. empty kwargs) propagate without being wrapped.
+        raise
     except Exception as e:
         logger.error(f"Unexpected error updating milestone {milestone_id}: {e}", exc_info=True)
         raise RuntimeError(f"Server error updating milestone: {e}")
@@ -2959,7 +3062,13 @@ def get_wiki_page(
 
 @mcp.tool(
     "create_wiki_page",
-    description="Creates a new wiki page. verbosity: 'minimal', 'standard' (default), 'full'. Uses default session if session_id not provided.",
+    description=(
+        "Creates a new wiki page. Optional fields (e.g. watchers) must be passed as a JSON "
+        "object via the `kwargs` parameter, NOT as top-level arguments — top-level args other "
+        "than the declared signature params are silently dropped by FastMCP. Allowed keys: see "
+        "ALLOWED_KWARGS['wiki_page'] in server.py. verbosity: 'minimal', 'standard' (default), "
+        "'full'. Uses default session if session_id not provided."
+    ),
 )
 def create_wiki_page(
     project_id: int,
@@ -3015,7 +3124,13 @@ def get_wiki_page_by_slug(
 
 @mcp.tool(
     "update_wiki_page",
-    description="Updates an existing wiki page. verbosity: 'minimal', 'standard' (default), 'full'. Uses default session if session_id not provided.",
+    description=(
+        "Updates an existing wiki page. Pass fields to update as a JSON object via the "
+        "`kwargs` parameter, NOT as top-level arguments — top-level args other than the "
+        "declared signature params are silently dropped by FastMCP. Calling with empty `kwargs` "
+        "raises ValueError. Allowed keys: see ALLOWED_KWARGS['wiki_page'] in server.py. "
+        "verbosity: 'minimal', 'standard' (default), 'full'. Uses default session if session_id not provided."
+    ),
 )
 def update_wiki_page(
     wiki_page_id: int,
@@ -3032,9 +3147,10 @@ def update_wiki_page(
     taiga_client_wrapper = _get_authenticated_client(actual_session_id)
     try:
         if not parsed_kwargs:
-            logger.info(f"No fields provided for update on wiki page {wiki_page_id}")
-            result = taiga_client_wrapper.api.wiki.get(wiki_page_id)
-            return _filter_response(result, "wiki_page", verbosity)
+            raise ValueError(
+                f"update_wiki_page called with no fields to update for wiki page {wiki_page_id}. "
+                "Pass fields inside the `kwargs` JSON object, not as top-level arguments."
+            )
 
         # Get current wiki page data to retrieve version
         current_page = taiga_client_wrapper.api.wiki.get(wiki_page_id)
@@ -3051,6 +3167,9 @@ def update_wiki_page(
     except TaigaException as e:
         logger.error(f"Taiga API error updating wiki page {wiki_page_id}: {e}", exc_info=False)
         raise e
+    except ValueError:
+        # Caller-bug ValueErrors (e.g. empty kwargs) propagate without being wrapped.
+        raise
     except Exception as e:
         logger.error(f"Unexpected error updating wiki page {wiki_page_id}: {e}", exc_info=True)
         raise RuntimeError(f"Server error updating wiki page: {e}")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -696,6 +696,14 @@ class TestTaigaTools:
         mock_client.api.tasks.get.assert_not_called()
         mock_client.api.tasks.edit.assert_not_called()
 
+    def test_update_task_missing_version(self, session_setup):
+        """Test update_task raises ValueError (not RuntimeError) when version is missing."""
+        session_id, mock_client = session_setup
+        mock_client.api.tasks.get.return_value = {"id": 789, "subject": "x"}
+        with pytest.raises(ValueError, match="Could not determine version"):
+            src.server.update_task(789, '{"subject": "new"}', session_id)
+        mock_client.api.tasks.edit.assert_not_called()
+
     def test_delete_task(self, session_setup):
         """Test delete_task."""
         session_id, mock_client = session_setup
@@ -833,6 +841,14 @@ class TestTaigaTools:
         with pytest.raises(ValueError, match="no fields to update"):
             src.server.update_issue(100, "{}", session_id)
         mock_client.api.issues.get.assert_not_called()
+        mock_client.api.issues.edit.assert_not_called()
+
+    def test_update_issue_missing_version(self, session_setup):
+        """Test update_issue raises ValueError (not RuntimeError) when version is missing."""
+        session_id, mock_client = session_setup
+        mock_client.api.issues.get.return_value = {"id": 100, "subject": "x"}
+        with pytest.raises(ValueError, match="Could not determine version"):
+            src.server.update_issue(100, '{"subject": "new"}', session_id)
         mock_client.api.issues.edit.assert_not_called()
 
     def test_delete_issue(self, session_setup):
@@ -1572,6 +1588,14 @@ class TestTaigaTools:
         mock_client.api.epics.get.assert_not_called()
         mock_client.api.epics.edit.assert_not_called()
 
+    def test_update_epic_missing_version(self, session_setup):
+        """Test update_epic raises ValueError (not RuntimeError) when version is missing."""
+        session_id, mock_client = session_setup
+        mock_client.api.epics.get.return_value = {"id": 200, "subject": "x"}
+        with pytest.raises(ValueError, match="Could not determine version"):
+            src.server.update_epic(200, '{"subject": "new"}', session_id)
+        mock_client.api.epics.edit.assert_not_called()
+
     def test_delete_epic(self, session_setup):
         """Test delete_epic."""
         session_id, mock_client = session_setup
@@ -1790,6 +1814,14 @@ class TestTaigaTools:
         with pytest.raises(ValueError, match="no fields to update"):
             src.server.update_wiki_page(400, None, session_id)
         mock_client.api.wiki.get.assert_not_called()
+        mock_client.api.wiki.edit.assert_not_called()
+
+    def test_update_wiki_page_missing_version(self, session_setup):
+        """Test update_wiki_page raises ValueError (not RuntimeError) when version is missing."""
+        session_id, mock_client = session_setup
+        mock_client.api.wiki.get.return_value = {"id": 400, "slug": "home", "content": "x"}
+        with pytest.raises(ValueError, match="Could not determine version"):
+            src.server.update_wiki_page(400, '{"content": "new"}', session_id)
         mock_client.api.wiki.edit.assert_not_called()
 
     def test_delete_wiki_page(self, session_setup):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -314,11 +314,11 @@ class TestTaigaTools:
         assert result["name"] == "New Name"
 
     def test_update_project_no_kwargs(self, session_setup):
-        """Test update_project with no kwargs returns current state."""
+        """Test update_project with no kwargs raises ValueError (caller bug)."""
         session_id, mock_client = session_setup
-        mock_client.api.projects.get.return_value = {"id": 123, "name": "Same", "version": 1}
-        result = src.server.update_project(123, "{}", session_id)
-        assert result["name"] == "Same"
+        with pytest.raises(ValueError, match="no fields to update"):
+            src.server.update_project(123, "{}", session_id)
+        mock_client.api.projects.get.assert_not_called()
         mock_client.api.projects.update.assert_not_called()
 
     def test_delete_project(self, session_setup):
@@ -531,11 +531,11 @@ class TestTaigaTools:
         )
 
     def test_update_user_story_no_kwargs(self, session_setup):
-        """Test update_user_story with no kwargs returns current state."""
+        """Test update_user_story with no kwargs raises ValueError (caller bug)."""
         session_id, mock_client = session_setup
-        mock_client.api.user_stories.get.return_value = {"id": 456, "subject": "Same", "version": 1}
-        result = src.server.update_user_story(456, "{}", session_id)
-        assert result["subject"] == "Same"
+        with pytest.raises(ValueError, match="no fields to update"):
+            src.server.update_user_story(456, "{}", session_id)
+        mock_client.api.user_stories.get.assert_not_called()
         mock_client.api.user_stories.edit.assert_not_called()
 
     def test_delete_user_story(self, session_setup):
@@ -689,11 +689,11 @@ class TestTaigaTools:
         )
 
     def test_update_task_no_kwargs(self, session_setup):
-        """Test update_task with no kwargs returns current state."""
+        """Test update_task with no kwargs raises ValueError (caller bug)."""
         session_id, mock_client = session_setup
-        mock_client.api.tasks.get.return_value = {"id": 789, "subject": "Same", "version": 1}
-        result = src.server.update_task(789, "{}", session_id)
-        assert result["subject"] == "Same"
+        with pytest.raises(ValueError, match="no fields to update"):
+            src.server.update_task(789, "{}", session_id)
+        mock_client.api.tasks.get.assert_not_called()
         mock_client.api.tasks.edit.assert_not_called()
 
     def test_delete_task(self, session_setup):
@@ -828,11 +828,11 @@ class TestTaigaTools:
         )
 
     def test_update_issue_no_kwargs(self, session_setup):
-        """Test update_issue with no kwargs returns current state."""
+        """Test update_issue with no kwargs raises ValueError (caller bug)."""
         session_id, mock_client = session_setup
-        mock_client.api.issues.get.return_value = {"id": 100, "subject": "Same", "version": 1}
-        result = src.server.update_issue(100, "{}", session_id)
-        assert result["subject"] == "Same"
+        with pytest.raises(ValueError, match="no fields to update"):
+            src.server.update_issue(100, "{}", session_id)
+        mock_client.api.issues.get.assert_not_called()
         mock_client.api.issues.edit.assert_not_called()
 
     def test_delete_issue(self, session_setup):
@@ -1565,11 +1565,11 @@ class TestTaigaTools:
         )
 
     def test_update_epic_no_kwargs(self, session_setup):
-        """Test update_epic with no kwargs returns current state."""
+        """Test update_epic with no kwargs raises ValueError (caller bug)."""
         session_id, mock_client = session_setup
-        mock_client.api.epics.get.return_value = {"id": 200, "subject": "Same", "version": 1}
-        result = src.server.update_epic(200, "{}", session_id)
-        assert result["subject"] == "Same"
+        with pytest.raises(ValueError, match="no fields to update"):
+            src.server.update_epic(200, "{}", session_id)
+        mock_client.api.epics.get.assert_not_called()
         mock_client.api.epics.edit.assert_not_called()
 
     def test_delete_epic(self, session_setup):
@@ -1664,11 +1664,11 @@ class TestTaigaTools:
         )
 
     def test_update_milestone_no_kwargs(self, session_setup):
-        """Test update_milestone with no kwargs returns current state."""
+        """Test update_milestone with no kwargs raises ValueError (caller bug)."""
         session_id, mock_client = session_setup
-        mock_client.api.milestones.get.return_value = {"id": 300, "name": "Sprint 1", "version": 1}
-        result = src.server.update_milestone(300, "{}", session_id)
-        assert result["name"] == "Sprint 1"
+        with pytest.raises(ValueError, match="no fields to update"):
+            src.server.update_milestone(300, "{}", session_id)
+        mock_client.api.milestones.get.assert_not_called()
         mock_client.api.milestones.edit.assert_not_called()
 
     def test_delete_milestone(self, session_setup):
@@ -1785,17 +1785,11 @@ class TestTaigaTools:
         )
 
     def test_update_wiki_page_no_kwargs(self, session_setup):
-        """Test update_wiki_page with no kwargs returns current state."""
+        """Test update_wiki_page with no kwargs raises ValueError (caller bug)."""
         session_id, mock_client = session_setup
-        mock_client.api.wiki.get.return_value = {
-            "id": 400,
-            "slug": "home",
-            "content": "# Welcome",
-            "project": 123,
-            "version": 1,
-        }
-        result = src.server.update_wiki_page(400, None, session_id)
-        assert result["id"] == 400
+        with pytest.raises(ValueError, match="no fields to update"):
+            src.server.update_wiki_page(400, None, session_id)
+        mock_client.api.wiki.get.assert_not_called()
         mock_client.api.wiki.edit.assert_not_called()
 
     def test_delete_wiki_page(self, session_setup):
@@ -1895,7 +1889,7 @@ class TestTaigaTools:
         session_id, mock_client = session_setup
         mock_client.api.get.return_value = {"id": 42}
 
-        with pytest.raises(RuntimeError, match="Server error"):
+        with pytest.raises(ValueError, match="Could not determine version"):
             src.server.add_comment(42, "issue", "Test comment", session_id)
 
     def test_list_comments(self, session_setup):

--- a/uv.lock
+++ b/uv.lock
@@ -712,7 +712,7 @@ cli = [
 
 [[package]]
 name = "mcp-taiga-bridge"
-version = "1.14.0"
+version = "1.14.1"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },


### PR DESCRIPTION
## Summary

- Rewrites the MCP tool `description=` strings for all 13 `create_*` / `update_*` tools that take `kwargs: Any = None`, so the LLM caller knows that optional fields (description, tags, status, milestone, …) must be packed into the `kwargs` JSON object rather than passed as top-level arguments (where FastMCP silently drops them)
- Replaces the silent `if not parsed_kwargs: return current_state` branch in 7 `update_*` tools with a `ValueError` that names the resource and shows the correct call shape
- Lets `ValueError` propagate cleanly through both the per-function try/except wrappers AND the shared `_execute_taiga_operation` helper, instead of being re-wrapped as `RuntimeError("Server error…")`

Closes #50

## Why

The previous behavior masked caller bugs as success: calling `update_user_story(user_story_id=776, description="…")` returned the unchanged record with no warning. The Python docstrings explained the kwargs convention, but FastMCP only surfaces the `description=` string to the model, so a fresh caller had no way to know without reading the source.

## Affected tools (13)

`create_project`, `update_project`, `create_user_story`, `update_user_story`, `create_task`, `update_task`, `create_issue`, `update_issue`, `create_epic`, `update_epic`, `update_milestone`, `create_wiki_page`, `update_wiki_page`

## Side-effect: ValueErrors now propagate unwrapped (broader than the affected-13)

Two scopes are affected:

1. **The 4 update functions with version-check ValueErrors** (`update_task`, `update_issue`, `update_epic`, `update_wiki_page`) already raised `ValueError("Could not determine version for X")` inside their `try` blocks before this PR. New tests in `tests/test_server.py` (`test_update_*_missing_version`) lock in that they now propagate as `ValueError` instead of being wrapped as `RuntimeError("Server error updating X: …")`.
2. **Every other `ValueError` raised inside an `_execute_taiga_operation` callable** (e.g. `User story with ref #X not found in project Y`, `Task subject cannot be empty.`, etc.) now also propagates as `ValueError` rather than being wrapped. The helper's docstring `Raises:` section is updated to document this. **Callers that were catching `RuntimeError` for these scenarios will need to switch to `ValueError`.** In practice this is not a downstream concern because the only consumer is FastMCP, which serializes any exception type into an MCP error response.

## Test plan

- [x] `uv run ruff check src/ tests/` — passes
- [x] `uv run ruff format --check src/ tests/` — passes
- [x] `./run_unit_tests.sh` — 283 passed, 1 warning (pre-existing pydantic deprecation)
- [x] 7 existing `test_update_*_no_kwargs` tests flipped from "returns current state" to `pytest.raises(ValueError)`
- [x] `test_add_comment_missing_version` aligned to actually assert `ValueError` (its docstring already said so; the old assertion expected the wrapped `RuntimeError`)
- [x] 4 new `test_update_*_missing_version` tests for task/issue/epic/wiki_page assert the new ValueError contract on missing-version
- [ ] Manual smoke after merge: re-pull container and verify `update_user_story` with kwargs JSON works and without kwargs raises a useful error

## Review feedback addressed

- `d9d0865` — removed unreachable `except ValueError: raise` in `login()`; corrected `create_wiki_page` / `update_wiki_page` descriptions (previously implied `watchers` was an allowed kwarg but `ALLOWED_KWARGS['wiki_page']` only allows `slug` and `content`); added 4 missing-version tests
- `a006fb4` — updated `_execute_taiga_operation` docstring `Raises:` section to document `ValueError` propagation