### PR TITLE
fix: surface DRF-format Taiga error bodies dropped by pytaigaclient (#57)

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -9,7 +9,7 @@ from contextlib import asynccontextmanager
 from typing import Any, AsyncIterator, Dict, List, Optional
 
 from mcp.server.fastmcp import FastMCP
-from pytaigaclient.exceptions import TaigaException
+from pytaigaclient.exceptions import TaigaAPIError, TaigaException
 
 from src.config import settings
 from src.taiga_client import TaigaClientWrapper
@@ -470,6 +470,38 @@ def _get_authenticated_client(session_id: str) -> TaigaClientWrapper:
     return client
 
 
+_TAIGA_API_ERROR_PLACEHOLDER = "No error message provided by API."
+
+
+def _repair_taiga_api_error(e: TaigaAPIError) -> None:
+    # Compensate for upstream pytaigaclient bug: TaigaAPIError.__init__ only looks
+    # for the legacy `_error_message` key and discards DRF-style validation bodies
+    # ({"field": ["msg", ...]}), leaving error_detail as a useless placeholder.
+    # See https://github.com/TETRA-2023/pytaiga-mcp/issues/57.
+    if getattr(e, "error_detail", None) != _TAIGA_API_ERROR_PLACEHOLDER:
+        return
+    response = getattr(e, "response", None)
+    if response is None:
+        return
+    try:
+        body = response.json()
+    except Exception:
+        return
+    if not isinstance(body, dict) or not body:
+        return
+    parts = []
+    for k, v in body.items():
+        if isinstance(v, list):
+            parts.append(f"{k}: {'; '.join(map(str, v))}")
+        else:
+            parts.append(f"{k}: {v}")
+    new_detail = " | ".join(parts)
+    if not new_detail:
+        return
+    e.error_detail = new_detail
+    e.args = (f"API Error {e.status_code}: {new_detail}",)
+
+
 def _execute_taiga_operation(operation_name: str, operation_callable, error_context: str = ""):
     """
     Execute a Taiga API operation with standardized error handling.
@@ -483,7 +515,9 @@ def _execute_taiga_operation(operation_name: str, operation_callable, error_cont
         The result of the operation
 
     Raises:
-        TaigaException: Re-raised from the API
+        TaigaException: Re-raised from the API. TaigaAPIError messages are repaired
+            in-place when the upstream client dropped a DRF-format error body
+            (see _repair_taiga_api_error).
         ValueError: Re-raised unwrapped from the operation callable (caller bugs:
             empty kwargs, missing required fields, ref-not-found, etc.) so callers
             see the original message rather than a generic "Server error" wrapper.
@@ -494,6 +528,10 @@ def _execute_taiga_operation(operation_name: str, operation_callable, error_cont
     try:
         result = operation_callable()
         return result
+    except TaigaAPIError as e:
+        _repair_taiga_api_error(e)
+        logger.error(f"Taiga API error in {operation_name}{context_str}: {e}", exc_info=False)
+        raise e
     except TaigaException as e:
         logger.error(f"Taiga API error in {operation_name}{context_str}: {e}", exc_info=False)
         raise e

--- a/src/server.py
+++ b/src/server.py
@@ -470,14 +470,37 @@ def _get_authenticated_client(session_id: str) -> TaigaClientWrapper:
     return client
 
 
+# Load-bearing string: must mirror pytaigaclient's TaigaAPIError default literal
+# exactly. If upstream changes the wording, the repair trigger silently no-ops
+# in production. The test_repair_taiga_api_error_drf_dict_list test constructs a
+# real TaigaAPIError and asserts this string, so a wording drift will fail CI.
 _TAIGA_API_ERROR_PLACEHOLDER = "No error message provided by API."
 
 
 def _repair_taiga_api_error(e: TaigaAPIError) -> None:
-    # Compensate for upstream pytaigaclient bug: TaigaAPIError.__init__ only looks
-    # for the legacy `_error_message` key and discards DRF-style validation bodies
-    # ({"field": ["msg", ...]}), leaving error_detail as a useless placeholder.
-    # See https://github.com/TETRA-2023/pytaiga-mcp/issues/57.
+    """Rewrite a TaigaAPIError's message in place when pytaigaclient dropped a DRF body.
+
+    pytaigaclient's TaigaAPIError.__init__ only reads the legacy `_error_message`
+    key, replacing modern Taiga dict-shaped DRF validation bodies (e.g.
+    `{"milestone_id": ["This field is required."]}`) with a placeholder string.
+    This helper detects that placeholder, reformats the actual body, and updates
+    both `error_detail` and `args` so `str(e)` reflects the repair.
+
+    Dict bodies render as `field: msg1; msg2 | field2: msg`. Nested non-scalar
+    values are JSON-encoded so they read as `field: {"k": "v"}` rather than
+    Python repr.
+
+    Scope: dict-shaped bodies only. Non-dict bodies (lists, primitives) cannot
+    reach this helper as a TaigaAPIError today — pytaigaclient's __init__ calls
+    `.get()` on the parsed body and raises AttributeError on lists, so they
+    propagate as a different exception class. Adding list handling here would
+    be dead code.
+
+    No-op when the detail is not the placeholder, when `e.response` is missing,
+    when `.json()` fails, when the body is not a non-empty dict, or when no
+    diagnostic content can be extracted. See
+    https://github.com/TETRA-2023/pytaiga-mcp/issues/57.
+    """
     if getattr(e, "error_detail", None) != _TAIGA_API_ERROR_PLACEHOLDER:
         return
     response = getattr(e, "response", None)
@@ -485,7 +508,10 @@ def _repair_taiga_api_error(e: TaigaAPIError) -> None:
         return
     try:
         body = response.json()
-    except Exception:
+    except (ValueError, AttributeError, TypeError):
+        # ValueError covers stdlib json.JSONDecodeError and requests'
+        # JSONDecodeError (both subclasses); AttributeError/TypeError cover
+        # response objects whose .json is missing or not callable.
         return
     if not isinstance(body, dict) or not body:
         return
@@ -493,8 +519,10 @@ def _repair_taiga_api_error(e: TaigaAPIError) -> None:
     for k, v in body.items():
         if isinstance(v, list):
             parts.append(f"{k}: {'; '.join(map(str, v))}")
-        else:
+        elif isinstance(v, (str, int, float, bool)) or v is None:
             parts.append(f"{k}: {v}")
+        else:
+            parts.append(f"{k}: {json.dumps(v)}")
     new_detail = " | ".join(parts)
     if not new_detail:
         return
@@ -529,6 +557,8 @@ def _execute_taiga_operation(operation_name: str, operation_callable, error_cont
         result = operation_callable()
         return result
     except TaigaAPIError as e:
+        # Must precede `except TaigaException` — TaigaAPIError is a subclass and
+        # Python matches the first compatible except clause.
         _repair_taiga_api_error(e)
         logger.error(f"Taiga API error in {operation_name}{context_str}: {e}", exc_info=False)
         raise e

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -165,6 +165,89 @@ class TestTaigaTools:
         with pytest.raises(RuntimeError, match="Server error in test_op"):
             src.server._execute_taiga_operation("test_op", failing)
 
+    # ─── TaigaAPIError repair tests (issue #57) ───────────────────────
+
+    @staticmethod
+    def _make_taiga_api_error(status_code, payload, *, json_decode_error=False):
+        """Build a TaigaAPIError mimicking the upstream init behaviour."""
+        from pytaigaclient.exceptions import TaigaAPIError
+
+        response = MagicMock()
+        response.status_code = status_code
+        if json_decode_error:
+            import requests
+
+            response.json.side_effect = requests.exceptions.JSONDecodeError("e", "doc", 0)
+            response.text = payload
+        else:
+            response.json.return_value = payload
+        return TaigaAPIError(status_code, response)
+
+    def test_repair_taiga_api_error_drf_dict_list(self):
+        """DRF-style {field: [msg, ...]} body should replace the placeholder detail."""
+        err = self._make_taiga_api_error(
+            400, {"milestone_id": ["This field is required.", "Must be int."]}
+        )
+        assert err.error_detail == "No error message provided by API."
+
+        src.server._repair_taiga_api_error(err)
+
+        assert err.error_detail == "milestone_id: This field is required.; Must be int."
+        assert str(err) == "API Error 400: milestone_id: This field is required.; Must be int."
+
+    def test_repair_taiga_api_error_drf_dict_scalar(self):
+        """DRF-style {field: scalar} body should also be formatted, not stringified."""
+        err = self._make_taiga_api_error(400, {"name": "already exists", "slug": "invalid"})
+
+        src.server._repair_taiga_api_error(err)
+
+        assert "name: already exists" in err.error_detail
+        assert "slug: invalid" in err.error_detail
+        assert str(err).startswith("API Error 400: ")
+
+    def test_repair_taiga_api_error_legacy_format_left_alone(self):
+        """Legacy {"_error_message": "..."} bodies are already handled upstream — don't touch."""
+        err = self._make_taiga_api_error(400, {"_error_message": "Legacy message"})
+        assert err.error_detail == "Legacy message"
+
+        src.server._repair_taiga_api_error(err)
+
+        assert err.error_detail == "Legacy message"
+        assert str(err) == "API Error 400: Legacy message"
+
+    def test_repair_taiga_api_error_non_json_body_left_alone(self):
+        """Non-JSON bodies set error_detail from response.text upstream — don't touch."""
+        err = self._make_taiga_api_error(500, "Internal Server Error", json_decode_error=True)
+        assert err.error_detail == "Internal Server Error"
+
+        src.server._repair_taiga_api_error(err)
+
+        assert err.error_detail == "Internal Server Error"
+
+    def test_repair_taiga_api_error_empty_dict_keeps_placeholder(self):
+        """Empty {} body has no fields to extract — placeholder stays."""
+        err = self._make_taiga_api_error(400, {})
+
+        src.server._repair_taiga_api_error(err)
+
+        assert err.error_detail == "No error message provided by API."
+
+    def test_execute_taiga_operation_repairs_drf_error(self):
+        """Errors flowing through the wrapper get repaired before re-raise."""
+        from pytaigaclient.exceptions import TaigaAPIError
+
+        err = self._make_taiga_api_error(400, {"milestone_id": ["This field is required."]})
+
+        def failing():
+            raise err
+
+        with pytest.raises(TaigaAPIError) as excinfo:
+            src.server._execute_taiga_operation("test_op", failing)
+
+        assert excinfo.value is err
+        assert excinfo.value.error_detail == "milestone_id: This field is required."
+        assert "milestone_id: This field is required." in str(excinfo.value)
+
     # ─── kwargs parsing and validation tests ──────────────────────────
 
     def test_parse_mcp_kwargs_empty(self):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -232,6 +232,35 @@ class TestTaigaTools:
 
         assert err.error_detail == "No error message provided by API."
 
+    def test_repair_taiga_api_error_no_response(self):
+        """If e.response is None, no-op safely (defensive)."""
+        err = self._make_taiga_api_error(400, {"will_not_be_read": "x"})
+        assert err.error_detail == "No error message provided by API."
+        err.response = None
+
+        src.server._repair_taiga_api_error(err)
+
+        assert err.error_detail == "No error message provided by API."
+
+    def test_repair_taiga_api_error_json_raises_during_repair(self):
+        """If response.json() raises during repair, no-op safely."""
+        err = self._make_taiga_api_error(400, {"will_not_be_read": "x"})
+        assert err.error_detail == "No error message provided by API."
+        err.response.json.side_effect = ValueError("boom")
+
+        src.server._repair_taiga_api_error(err)
+
+        assert err.error_detail == "No error message provided by API."
+
+    def test_repair_taiga_api_error_nested_dict_value(self):
+        """Nested non-scalar values are JSON-encoded, not Python-repr'd."""
+        err = self._make_taiga_api_error(400, {"field": {"nested": "msg"}})
+
+        src.server._repair_taiga_api_error(err)
+
+        assert err.error_detail == 'field: {"nested": "msg"}'
+        assert str(err) == 'API Error 400: field: {"nested": "msg"}'
+
     def test_execute_taiga_operation_repairs_drf_error(self):
         """Errors flowing through the wrapper get repaired before re-raise."""
         from pytaigaclient.exceptions import TaigaAPIError

--- a/uv.lock
+++ b/uv.lock
@@ -712,7 +712,7 @@ cli = [
 
 [[package]]
 name = "mcp-taiga-bridge"
-version = "1.14.3"
+version = "1.14.4"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },


### PR DESCRIPTION
## Summary

Closes #57.

`pytaigaclient`'s `TaigaAPIError.__init__` only reads the legacy `_error_message` key from the response body, discarding modern Taiga DRF-style validation errors (e.g. `{"milestone_id": ["This field is required."]}`) and replacing them with the placeholder string `"No error message provided by API."`. This makes every Taiga validation error opaque to MCP users — it compounded the diagnosis of #55 and will compound any future validation bug.

Per the recommendation on #57 (option **B2** — wrap at `_execute_taiga_operation`):

- Add `_repair_taiga_api_error(e)` helper. No-op unless `e.error_detail` matches the upstream placeholder.
- When the placeholder is detected, parse `e.response.json()` and re-format any dict-shaped body into a `field: msg1; msg2 | field2: ...` string. Update both `e.error_detail` **and** `e.args` so that `str(e)` (which is what the wrapper logs and what FastMCP propagates) reflects the repaired detail.
- Add a dedicated `except TaigaAPIError` branch in `_execute_taiga_operation` that calls the repair before the existing log + re-raise.

Legacy single-string `_error_message` bodies and non-JSON bodies are deliberately left untouched — `pytaigaclient` already handles those correctly upstream.

Option A (upstream PR) was ruled out — the `pytaigaclient` repo has had no commits since 2025-04-11 and the maintainer's other repos show the same dormancy pattern. See the audit comment on #57. Option B3 (vendor `pytaigaclient` entirely) is worth a separate tracking issue.

## Test plan

- [x] Unit tests pass (`uv run pytest tests/test_server.py` — 289 passed)
- [x] `ruff check` + `ruff format --check` clean
- [x] Pre-commit hooks pass
- [x] New tests cover: DRF dict-of-lists, DRF dict-of-scalars, legacy `_error_message` (untouched), non-JSON body (untouched), empty `{}` (placeholder retained), end-to-end repair through `_execute_taiga_operation`
- [ ] Manual smoke: trigger a known DRF validation error (e.g. `bulk_create_tasks` without `milestone_id`, the #55 repro) and confirm the Claude-facing error message now reads `milestone_id: This field is required.` rather than the placeholder