### PR TITLE
fix: validate milestone_id on bulk_create_tasks with Kanban-aware error (#55)

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -3736,22 +3736,33 @@ def bulk_create_user_stories(
         "All tasks are created in the specified project and milestone (sprint), "
         "optionally linked to a user story. Note: Taiga's /tasks/bulk_create "
         "endpoint is sprint-scoped — milestone_id is required by the Taiga API "
-        "(verified on Taiga 2.40+). If user_story_id is provided, the user story "
-        "must belong to the specified milestone — Taiga validates this alignment "
-        "and rejects mismatches with 'Invalid user story id'. Returns the list of "
-        "created tasks. Uses default session if session_id not provided."
+        "(verified on Taiga 2.40+) regardless of project settings. Kanban-only "
+        "projects (backlog not activated) cannot use this endpoint at all; fall "
+        "back to individual create_task calls in a loop. If user_story_id is "
+        "provided, the user story must belong to the specified milestone — "
+        "Taiga validates this alignment and rejects mismatches with 'Invalid "
+        "user story id'. Returns the list of created tasks. Uses default "
+        "session if session_id not provided."
     ),
 )
 def bulk_create_tasks(
     project_id: int,
     subjects: List[str],
-    milestone_id: int,
+    milestone_id: Optional[int] = None,
     user_story_id: Optional[int] = None,
     session_id: Optional[str] = None,
     verbosity: str = "standard",
 ) -> List[Dict[str, Any]]:
     """Bulk-creates tasks from a list of subject strings within a sprint."""
     cleaned = _clean_subjects(subjects)
+    if milestone_id is None:
+        raise ValueError(
+            "milestone_id is required by Taiga's /tasks/bulk_create endpoint "
+            "(verified on Taiga 2.40+). The endpoint is sprint-scoped — there "
+            "is no API mode that bulk-creates tasks outside a milestone. "
+            "For Kanban-only projects (backlog not activated, no milestones), "
+            "fall back to individual create_task calls in a loop."
+        )
     actual_session_id = _get_session_id(session_id)
     logger.info(
         f"Executing bulk_create_tasks: {len(cleaned)} tasks in project {project_id}, "

--- a/src/server.py
+++ b/src/server.py
@@ -3731,27 +3731,41 @@ def bulk_create_user_stories(
 
 @mcp.tool(
     "bulk_create_tasks",
-    description="Creates multiple tasks at once from a list of subjects. All tasks are created in the specified project, optionally linked to a user story. Returns the list of created tasks. Uses default session if session_id not provided.",
+    description=(
+        "Creates multiple tasks at once from a list of subjects within a sprint. "
+        "All tasks are created in the specified project and milestone (sprint), "
+        "optionally linked to a user story. Note: Taiga's /tasks/bulk_create "
+        "endpoint is sprint-scoped — milestone_id is required by the Taiga API "
+        "(verified on Taiga 2.40+). If user_story_id is provided, the user story "
+        "must belong to the specified milestone — Taiga validates this alignment "
+        "and rejects mismatches with 'Invalid user story id'. Returns the list of "
+        "created tasks. Uses default session if session_id not provided."
+    ),
 )
 def bulk_create_tasks(
     project_id: int,
     subjects: List[str],
+    milestone_id: int,
     user_story_id: Optional[int] = None,
     session_id: Optional[str] = None,
     verbosity: str = "standard",
 ) -> List[Dict[str, Any]]:
-    """Bulk-creates tasks from a list of subject strings."""
+    """Bulk-creates tasks from a list of subject strings within a sprint."""
     cleaned = _clean_subjects(subjects)
     actual_session_id = _get_session_id(session_id)
     logger.info(
         f"Executing bulk_create_tasks: {len(cleaned)} tasks in project {project_id}, "
-        f"session {actual_session_id[:8]}..."
+        f"milestone {milestone_id}, session {actual_session_id[:8]}..."
     )
     taiga_client_wrapper = _get_authenticated_client(actual_session_id)
 
     def do_bulk():
         bulk_tasks = "\n".join(cleaned)
-        payload: Dict[str, Any] = {"project_id": project_id, "bulk_tasks": bulk_tasks}
+        payload: Dict[str, Any] = {
+            "project_id": project_id,
+            "bulk_tasks": bulk_tasks,
+            "milestone_id": milestone_id,
+        }
         if user_story_id is not None:
             payload["us_id"] = user_story_id
         result = taiga_client_wrapper.api.post("/tasks/bulk_create", json=payload)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2424,9 +2424,14 @@ class TestTaigaTools:
             src.server.bulk_create_tasks(21, [], milestone_id=89)
 
     def test_bulk_create_tasks_missing_milestone_raises(self):
-        """Test bulk_create_tasks signature requires milestone_id (issue #55)."""
-        with pytest.raises(TypeError, match="milestone_id"):
-            src.server.bulk_create_tasks(21, ["Task A"])  # type: ignore[call-arg]
+        """Test bulk_create_tasks raises a Kanban-aware ValueError when milestone_id missing (#55)."""
+        with pytest.raises(ValueError, match="milestone_id is required"):
+            src.server.bulk_create_tasks(21, ["Task A"])
+
+    def test_bulk_create_tasks_missing_milestone_mentions_kanban_workaround(self):
+        """The missing-milestone error must point Kanban-only callers at create_task."""
+        with pytest.raises(ValueError, match="create_task"):
+            src.server.bulk_create_tasks(21, ["Task A"])
 
     def test_bulk_create_issues(self, session_setup):
         """Test bulk_create_issues calls correct endpoint."""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2395,13 +2395,15 @@ class TestTaigaTools:
         assert call_json["bulk_stories"] == "Story A"
 
     def test_bulk_create_tasks(self, session_setup):
-        """Test bulk_create_tasks calls correct endpoint."""
+        """Test bulk_create_tasks calls correct endpoint with required milestone_id."""
         session_id, mock_client = session_setup
         mock_client.api.post.return_value = [{"id": 1, "subject": "Task A"}]
-        result = src.server.bulk_create_tasks(21, ["Task A"], session_id=session_id)
+        result = src.server.bulk_create_tasks(
+            21, ["Task A"], milestone_id=89, session_id=session_id
+        )
         mock_client.api.post.assert_called_once_with(
             "/tasks/bulk_create",
-            json={"project_id": 21, "bulk_tasks": "Task A"},
+            json={"project_id": 21, "bulk_tasks": "Task A", "milestone_id": 89},
         )
         assert len(result) == 1
 
@@ -2409,14 +2411,22 @@ class TestTaigaTools:
         """Test bulk_create_tasks includes us_id when user_story_id provided."""
         session_id, mock_client = session_setup
         mock_client.api.post.return_value = [{"id": 1, "subject": "Task A"}]
-        src.server.bulk_create_tasks(21, ["Task A"], user_story_id=5, session_id=session_id)
+        src.server.bulk_create_tasks(
+            21, ["Task A"], milestone_id=89, user_story_id=5, session_id=session_id
+        )
         call_json = mock_client.api.post.call_args[1]["json"]
         assert call_json["us_id"] == 5
+        assert call_json["milestone_id"] == 89
 
     def test_bulk_create_tasks_empty_raises(self):
         """Test bulk_create_tasks raises on empty list before checking session."""
         with pytest.raises(ValueError, match="Subjects list cannot be empty"):
-            src.server.bulk_create_tasks(21, [])
+            src.server.bulk_create_tasks(21, [], milestone_id=89)
+
+    def test_bulk_create_tasks_missing_milestone_raises(self):
+        """Test bulk_create_tasks signature requires milestone_id (issue #55)."""
+        with pytest.raises(TypeError, match="milestone_id"):
+            src.server.bulk_create_tasks(21, ["Task A"])  # type: ignore[call-arg]
 
     def test_bulk_create_issues(self, session_setup):
         """Test bulk_create_issues calls correct endpoint."""


### PR DESCRIPTION
## Summary

Closes #55.

Taiga 2.40+'s \`/tasks/bulk_create\` validator requires \`milestone_id\` (verified at the wire level — see the investigation comment on #55). Both \`pytaigaclient.tasks.bulk_create\` and our MCP wrapper omitted it, so every call to \`mcp__taiga__bulk_create_tasks\` returned HTTP 400 with the DRF body \`{\"milestone_id\": [\"This field is required.\"]}\`. PR #58 made that body now visible — this PR fixes the underlying cause and adds Kanban-aware guidance for the corner case where a project simply has no milestones to pass.

The endpoint is **sprint-scoped by Taiga's design** regardless of project settings. Kanban-only projects (\`is_backlog_activated = False\`, no milestones) cannot use this endpoint at all — the validator runs before any project-level config check.

## Changes

- Add \`milestone_id: Optional[int] = None\` to \`bulk_create_tasks\`. When missing, raise a clean \`ValueError\` that:
  - Explains the Taiga-side constraint (sprint-scoped endpoint, not our wrapper's choice)
  - Explicitly flags Kanban-only projects as a no-go
  - Points callers at the \`create_task\` in-a-loop fallback
- Pass \`milestone_id\` through in the POST payload alongside \`project_id\` and \`bulk_tasks\`.
- Update the MCP tool description with the same Kanban guidance and document the US↔milestone alignment validation Taiga enforces (\"Invalid user story id\" if \`user_story_id\` doesn't belong to the specified milestone).
- Tests: update existing 3 tests to pass \`milestone_id\` and assert it lands in the payload; add 2 tests covering the Kanban-aware ValueError (raises on missing \`milestone_id\`, error text mentions \`create_task\` workaround).

## Why this is not a breaking change

Earlier draft of this PR made \`milestone_id\` required at the Python signature level (\`fix!\`). Discussion on the PR pointed out that Kanban-only callers — who have no milestone to pass — would hit a confusing \`TypeError\` instead of the actionable workaround. Switched to \`Optional[int] = None\` with an explicit \`ValueError\`. The function still accepts the same call shape; only the failure mode changes from a post-call HTTP 400 to a pre-call \`ValueError\`. Both pre-existing failure paths fail, this one fails better, no merging caller's working code path becomes broken.

## Test plan

- [x] Unit tests pass (\`uv run pytest tests/test_server.py\` — 294 passed)
- [x] \`ruff check\` + \`ruff format --check\` clean
- [x] Pre-commit hooks pass
- [x] Manual smoke against \`taiga.tetra-ai.fr\`: call \`bulk_create_tasks(project_id=9, subjects=[\"T1\",\"T2\"], milestone_id=<real_id>)\` and confirm tasks are created and linked to the milestone.
- [x] Manual smoke: call without \`milestone_id\` and confirm the Kanban-aware ValueError is surfaced (rather than a Taiga-side 400).
- [x] Manual smoke: call with \`user_story_id\` belonging to a different milestone and confirm Taiga's \"Invalid user story id\" is surfaced (now visible thanks to PR #58).