### PR TITLE
feat: add swimlane CRUD tools and bulk swimlane assignment (#24)

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -3078,12 +3078,12 @@ def list_swimlanes(
         "per-swimlane status configuration from the project's user-story statuses. "
         "Note: if this is the first swimlane in the project, Taiga marks it "
         "'default' and the project enters swimlanes-enabled mode; existing user "
-        "stories are auto-assigned to that default swimlane. The default swimlane "
-        "cannot be deleted through any Taiga API call ('The default swimlane "
-        "cannot be deleted') — removing it requires admin UI access. Confirm "
-        "intent before creating the first swimlane on a Kanban project. "
-        "verbosity: 'minimal', 'standard' (default), 'full'. Uses default session "
-        "if session_id not provided."
+        "stories are auto-assigned to that default swimlane. To revert to a "
+        "no-swimlanes state, delete all non-default swimlanes first (each with "
+        "move_to=<default_id>) then delete the default — Taiga only blocks "
+        "deleting the default while other swimlanes still exist. verbosity: "
+        "'minimal', 'standard' (default), 'full'. Uses default session if "
+        "session_id not provided."
     ),
 )
 def create_swimlane(
@@ -3182,13 +3182,16 @@ def update_swimlane(
     description=(
         "Deletes a swimlane by its ID. User stories are not deleted — they "
         "migrate (see move_to). Two Taiga API constraints to know: (1) the "
-        "first swimlane created on a project becomes the 'default' and cannot "
-        "be deleted via any API call; removing it requires admin UI access. "
-        "(2) When deleting a non-default swimlane that has user stories "
-        "assigned, you must specify move_to (an existing swimlane ID in the "
-        "same project) to migrate them; without move_to, Taiga rejects with "
-        "'Cannot set swimlane to None if there are available swimlanes'. Uses "
-        "default session if session_id not provided."
+        "default swimlane (first one created on the project) cannot be deleted "
+        "while other swimlanes still exist — Taiga returns 'The default "
+        "swimlane cannot be deleted'. To delete it, first delete all non-default "
+        "swimlanes (each with move_to=<default_id>); once the default is the "
+        "only one left, deletion succeeds and the project reverts to no-"
+        "swimlanes state. (2) Deleting a non-default swimlane that has user "
+        "stories assigned requires move_to (an existing swimlane ID in the same "
+        "project) to migrate them; without move_to, Taiga rejects with 'Cannot "
+        "set swimlane to None if there are available swimlanes'. Uses default "
+        "session if session_id not provided."
     ),
 )
 def delete_swimlane(
@@ -3197,6 +3200,8 @@ def delete_swimlane(
     session_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Deletes a swimlane by ID, optionally migrating its user stories to move_to."""
+    if move_to is not None and move_to == swimlane_id:
+        raise ValueError(f"move_to ({move_to}) cannot be the same as swimlane_id ({swimlane_id}).")
     actual_session_id = _get_session_id(session_id)
     logger.warning(
         f"Executing delete_swimlane ID {swimlane_id} "
@@ -3205,10 +3210,8 @@ def delete_swimlane(
     taiga_client_wrapper = _get_authenticated_client(actual_session_id)
 
     def do_delete():
-        path = f"/swimlanes/{swimlane_id}"
-        if move_to is not None:
-            path = f"{path}?moveTo={move_to}"
-        taiga_client_wrapper.api.delete(path)
+        params = {"moveTo": move_to} if move_to is not None else None
+        taiga_client_wrapper.api.delete(f"/swimlanes/{swimlane_id}", params=params)
         return {"status": "deleted", "swimlane_id": swimlane_id, "moved_to": move_to}
 
     return _execute_taiga_operation("delete_swimlane", do_delete, f"swimlane {swimlane_id}")

--- a/src/server.py
+++ b/src/server.py
@@ -102,6 +102,7 @@ ALLOWED_KWARGS: Dict[str, set] = {
         "due_date",
         "due_date_reason",
         "epics",
+        "swimlane",
     },
     "task": {
         "subject",
@@ -155,6 +156,10 @@ ALLOWED_KWARGS: Dict[str, set] = {
         "slug",
         "order",
         "watchers",
+    },
+    "swimlane": {
+        "name",
+        "order",
     },
     "wiki_page": {
         "slug",
@@ -217,6 +222,7 @@ RESPONSE_FIELDS: Dict[str, Dict[str, Optional[List[str]]]] = {
             "assigned_to",
             "assigned_to_extra_info",
             "milestone",
+            "swimlane",
             "project",
             "tags",
             "is_blocked",
@@ -304,6 +310,11 @@ RESPONSE_FIELDS: Dict[str, Dict[str, Optional[List[str]]]] = {
             "project",
             "version",
         ],
+        "full": None,
+    },
+    "swimlane": {
+        "minimal": ["id", "name", "project"],
+        "standard": ["id", "name", "order", "project"],
         "full": None,
     },
     "member": {
@@ -3028,6 +3039,181 @@ def delete_milestone(milestone_id: int, session_id: Optional[str] = None) -> Dic
     return _execute_taiga_operation("delete_milestone", do_delete, f"milestone {milestone_id}")
 
 
+# --- Swimlane Tools ---
+
+
+@mcp.tool(
+    "list_swimlanes",
+    description=(
+        "Lists kanban swimlanes within a specific project. Swimlanes are horizontal "
+        "groupings on the Kanban board (typically aligned with epics, teams, or "
+        "initiatives). verbosity: 'minimal' (id/name/project), 'standard' (default — "
+        "adds 'order'), 'full' (includes per-swimlane status configuration). Uses "
+        "default session if session_id not provided."
+    ),
+)
+def list_swimlanes(
+    project_id: int, session_id: Optional[str] = None, verbosity: str = "standard"
+) -> List[Dict[str, Any]]:
+    """Lists swimlanes for a project."""
+    actual_session_id = _get_session_id(session_id)
+    logger.info(
+        f"Executing list_swimlanes for project {project_id}, session {actual_session_id[:8]}..."
+    )
+    taiga_client_wrapper = _get_authenticated_client(actual_session_id)
+
+    result = _execute_taiga_operation(
+        "list_swimlanes",
+        lambda: taiga_client_wrapper.list_resources("swimlanes", project_id=project_id),
+        f"project {project_id}",
+    )
+    return _filter_response(result, "swimlane", verbosity)
+
+
+@mcp.tool(
+    "create_swimlane",
+    description=(
+        "Creates a new kanban swimlane within a project. Required: project_id and "
+        "name. Taiga auto-assigns 'order' (timestamp-based) and auto-populates "
+        "per-swimlane status configuration from the project's user-story statuses. "
+        "Note: if this is the first swimlane in the project, Taiga marks it "
+        "'default' and the project enters swimlanes-enabled mode; existing user "
+        "stories are auto-assigned to that default swimlane. The default swimlane "
+        "cannot be deleted through any Taiga API call ('The default swimlane "
+        "cannot be deleted') — removing it requires admin UI access. Confirm "
+        "intent before creating the first swimlane on a Kanban project. "
+        "verbosity: 'minimal', 'standard' (default), 'full'. Uses default session "
+        "if session_id not provided."
+    ),
+)
+def create_swimlane(
+    project_id: int,
+    name: str,
+    session_id: Optional[str] = None,
+    verbosity: str = "standard",
+) -> Dict[str, Any]:
+    """Creates a swimlane. Requires project_id and name."""
+    if not name:
+        raise ValueError("Swimlane requires a non-empty name.")
+    actual_session_id = _get_session_id(session_id)
+    logger.info(
+        f"Executing create_swimlane '{name}' in project {project_id}, "
+        f"session {actual_session_id[:8]}..."
+    )
+    taiga_client_wrapper = _get_authenticated_client(actual_session_id)
+
+    def do_create():
+        return taiga_client_wrapper.api.post(
+            "/swimlanes",
+            json={"project": project_id, "name": name},
+        )
+
+    result = _execute_taiga_operation("create_swimlane", do_create, f"swimlane '{name}'")
+    return _filter_response(result, "swimlane", verbosity)
+
+
+@mcp.tool(
+    "get_swimlane",
+    description=(
+        "Gets details about a specific swimlane by its ID, including its per-status "
+        "configuration. verbosity: 'minimal', 'standard' (default), 'full' (includes "
+        "embedded statuses). Uses default session if session_id not provided."
+    ),
+)
+def get_swimlane(
+    swimlane_id: int, session_id: Optional[str] = None, verbosity: str = "standard"
+) -> Dict[str, Any]:
+    """Retrieves swimlane details by ID."""
+    actual_session_id = _get_session_id(session_id)
+    logger.info(f"Executing get_swimlane ID {swimlane_id} for session {actual_session_id[:8]}...")
+    taiga_client_wrapper = _get_authenticated_client(actual_session_id)
+
+    result = _execute_taiga_operation(
+        "get_swimlane",
+        lambda: taiga_client_wrapper.api.get(f"/swimlanes/{swimlane_id}"),
+        f"swimlane {swimlane_id}",
+    )
+    return _filter_response(result, "swimlane", verbosity)
+
+
+@mcp.tool(
+    "update_swimlane",
+    description=(
+        "Updates a swimlane's name or order. Pass fields to update as a JSON object "
+        "via the `kwargs` parameter, NOT as top-level arguments — top-level args "
+        "other than the declared signature params are silently dropped by FastMCP. "
+        "Calling with empty `kwargs` raises ValueError. Allowed keys: see "
+        "ALLOWED_KWARGS['swimlane'] in server.py (name, order). Swimlanes do not "
+        "use optimistic concurrency control — no version field is required. "
+        "verbosity: 'minimal', 'standard' (default), 'full'. Uses default session "
+        "if session_id not provided."
+    ),
+)
+def update_swimlane(
+    swimlane_id: int,
+    kwargs: Any = None,
+    session_id: Optional[str] = None,
+    verbosity: str = "standard",
+) -> Dict[str, Any]:
+    """Updates a swimlane. Pass fields as kwargs JSON (e.g., {"name": "Security"})."""
+    actual_session_id = _get_session_id(session_id)
+    parsed_kwargs = _validate_kwargs("swimlane", _parse_mcp_kwargs({"kwargs": kwargs}))
+    logger.info(
+        f"Executing update_swimlane ID {swimlane_id} for session {actual_session_id[:8]} "
+        f"with data: {parsed_kwargs}"
+    )
+    taiga_client_wrapper = _get_authenticated_client(actual_session_id)
+    if not parsed_kwargs:
+        raise ValueError(
+            f"update_swimlane called with no fields to update for swimlane {swimlane_id}. "
+            "Pass fields inside the `kwargs` JSON object, not as top-level arguments."
+        )
+
+    result = _execute_taiga_operation(
+        "update_swimlane",
+        lambda: taiga_client_wrapper.api.patch(f"/swimlanes/{swimlane_id}", json=parsed_kwargs),
+        f"swimlane {swimlane_id}",
+    )
+    return _filter_response(result, "swimlane", verbosity)
+
+
+@mcp.tool(
+    "delete_swimlane",
+    description=(
+        "Deletes a swimlane by its ID. User stories are not deleted — they "
+        "migrate (see move_to). Two Taiga API constraints to know: (1) the "
+        "first swimlane created on a project becomes the 'default' and cannot "
+        "be deleted via any API call; removing it requires admin UI access. "
+        "(2) When deleting a non-default swimlane that has user stories "
+        "assigned, you must specify move_to (an existing swimlane ID in the "
+        "same project) to migrate them; without move_to, Taiga rejects with "
+        "'Cannot set swimlane to None if there are available swimlanes'. Uses "
+        "default session if session_id not provided."
+    ),
+)
+def delete_swimlane(
+    swimlane_id: int,
+    move_to: Optional[int] = None,
+    session_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Deletes a swimlane by ID, optionally migrating its user stories to move_to."""
+    actual_session_id = _get_session_id(session_id)
+    logger.warning(
+        f"Executing delete_swimlane ID {swimlane_id} "
+        f"(move_to={move_to}) for session {actual_session_id[:8]}..."
+    )
+    taiga_client_wrapper = _get_authenticated_client(actual_session_id)
+
+    def do_delete():
+        path = f"/swimlanes/{swimlane_id}"
+        if move_to is not None:
+            path = f"{path}?moveTo={move_to}"
+        taiga_client_wrapper.api.delete(path)
+        return {"status": "deleted", "swimlane_id": swimlane_id, "moved_to": move_to}
+
+    return _execute_taiga_operation("delete_swimlane", do_delete, f"swimlane {swimlane_id}")
+
+
 # --- User Management Tools ---
 
 
@@ -3894,6 +4080,64 @@ def bulk_update_user_story_milestone(
         "bulk_update_user_story_milestone",
         do_bulk,
         f"{len(bulk_stories)} stories to milestone {milestone_id}",
+    )
+
+
+@mcp.tool(
+    "bulk_update_user_story_swimlane",
+    description=(
+        "Assigns multiple user stories to a kanban swimlane in a single call. "
+        "Requires project_id, status_id, swimlane_id, and a list of user story IDs. "
+        "Per-status constraint (Taiga API): all user stories in user_story_ids must "
+        "currently share the given status_id — this endpoint is the same one Taiga's "
+        "Kanban UI uses to drop a column-worth of cards into a swimlane. To move "
+        "stories spanning multiple statuses, group by status and call this tool "
+        "once per status group. The order of IDs in user_story_ids determines "
+        "kanban_order within the (status, swimlane) cell. For single-story "
+        'assignment, use update_user_story with kwargs={"swimlane": <id>} instead. '
+        "Uses default session if session_id not provided."
+    ),
+)
+def bulk_update_user_story_swimlane(
+    project_id: int,
+    status_id: int,
+    swimlane_id: int,
+    user_story_ids: List[int],
+    session_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Bulk-assigns user stories sharing a status to a swimlane via Taiga's bulk_update_kanban_order endpoint."""
+    if not user_story_ids:
+        raise ValueError("user_story_ids list cannot be empty.")
+    actual_session_id = _get_session_id(session_id)
+    logger.info(
+        f"Executing bulk_update_user_story_swimlane: {len(user_story_ids)} stories -> "
+        f"swimlane {swimlane_id} (status {status_id}) in project {project_id}, "
+        f"session {actual_session_id[:8]}..."
+    )
+    taiga_client_wrapper = _get_authenticated_client(actual_session_id)
+
+    def do_bulk():
+        taiga_client_wrapper.api.post(
+            "/userstories/bulk_update_kanban_order",
+            json={
+                "project_id": project_id,
+                "status_id": status_id,
+                "swimlane_id": swimlane_id,
+                "bulk_userstories": user_story_ids,
+            },
+        )
+        return {
+            "status": "updated",
+            "project_id": project_id,
+            "swimlane_id": swimlane_id,
+            "status_id": status_id,
+            "stories_moved": len(user_story_ids),
+        }
+
+    return _execute_taiga_operation(
+        "bulk_update_user_story_swimlane",
+        do_bulk,
+        f"{len(user_story_ids)} stories to swimlane {swimlane_id} (status {status_id})",
     )
 
 

--- a/src/taiga_client.py
+++ b/src/taiga_client.py
@@ -24,6 +24,7 @@ _RESOURCE_ENDPOINTS = {
     "priorities": "/priorities",
     "severities": "/severities",
     "points": "/points",
+    "swimlanes": "/swimlanes",
 }
 
 _NO_PAGINATION_HEADERS = {"x-disable-pagination": "True"}

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1892,22 +1892,31 @@ class TestTaigaTools:
         assert sent == {"name": "Security"}, f"unexpected payload: {sent}"
 
     def test_delete_swimlane(self, session_setup):
-        """Test delete_swimlane DELETEs /swimlanes/{id} without move_to."""
+        """Test delete_swimlane DELETEs /swimlanes/{id} with params=None when move_to absent."""
         session_id, mock_client = session_setup
         mock_client.api.delete.return_value = None
         result = src.server.delete_swimlane(1, session_id=session_id)
-        mock_client.api.delete.assert_called_once_with("/swimlanes/1")
+        mock_client.api.delete.assert_called_once_with("/swimlanes/1", params=None)
         assert result["status"] == "deleted"
         assert result["swimlane_id"] == 1
         assert result["moved_to"] is None
 
     def test_delete_swimlane_with_move_to(self, session_setup):
-        """Test delete_swimlane appends ?moveTo= when migrating user stories."""
+        """Test delete_swimlane sends params={'moveTo': ...} when migrating user stories."""
         session_id, mock_client = session_setup
         mock_client.api.delete.return_value = None
         result = src.server.delete_swimlane(1, move_to=2, session_id=session_id)
-        mock_client.api.delete.assert_called_once_with("/swimlanes/1?moveTo=2")
+        mock_client.api.delete.assert_called_once_with("/swimlanes/1", params={"moveTo": 2})
+        assert result["status"] == "deleted"
+        assert result["swimlane_id"] == 1
         assert result["moved_to"] == 2
+
+    def test_delete_swimlane_move_to_same_id_raises(self, session_setup):
+        """Test delete_swimlane rejects move_to == swimlane_id before any API call."""
+        session_id, mock_client = session_setup
+        with pytest.raises(ValueError, match="move_to .* cannot be the same as swimlane_id"):
+            src.server.delete_swimlane(1, move_to=1, session_id=session_id)
+        mock_client.api.delete.assert_not_called()
 
     def test_user_story_swimlane_kwarg_passes_through(self, session_setup):
         """Adding 'swimlane' to ALLOWED_KWARGS['user_story'] enables update_user_story assignment."""
@@ -2751,11 +2760,36 @@ class TestResponseFiltering:
 
     def test_filter_minimal_includes_project_where_applicable(self):
         """Resources with project association must include project in minimal."""
-        project_resources = ["user_story", "task", "issue", "epic", "milestone", "wiki_page"]
+        project_resources = [
+            "user_story",
+            "task",
+            "issue",
+            "epic",
+            "milestone",
+            "wiki_page",
+            "swimlane",
+        ]
         for resource_type in project_resources:
             assert "project" in src.server.RESPONSE_FIELDS[resource_type]["minimal"], (
                 f"{resource_type} missing project in minimal"
             )
+
+    def test_filter_swimlane_verbosity_levels(self):
+        """Swimlane response filter trims correctly per verbosity (issue #24)."""
+        full = {
+            "id": 1,
+            "name": "Security",
+            "order": 100,
+            "project": 9,
+            "statuses": [{"id": 65, "name": "New"}],  # large nested data, only in 'full'
+        }
+        minimal = src.server._filter_response(full, "swimlane", "minimal")
+        assert set(minimal.keys()) == {"id", "name", "project"}
+        standard = src.server._filter_response(full, "swimlane", "standard")
+        assert set(standard.keys()) == {"id", "name", "order", "project"}
+        result_full = src.server._filter_response(full, "swimlane", "full")
+        assert result_full == full  # untouched
+        assert "statuses" in result_full
 
     def test_filter_response_handles_none(self):
         """_filter_response should return None when given None."""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1815,6 +1815,110 @@ class TestTaigaTools:
         assert result["status"] == "deleted"
         assert result["milestone_id"] == 300
 
+    # ─── Swimlane tools tests (issue #24) ─────────────────────────────
+
+    def test_list_swimlanes(self, session_setup):
+        """Test list_swimlanes routes through list_resources('swimlanes', ...)."""
+        session_id, mock_client = session_setup
+        mock_client.list_resources.return_value = [
+            {"id": 1, "name": "Security", "order": 100, "project": 9}
+        ]
+        result = src.server.list_swimlanes(9, session_id)
+        assert len(result) == 1
+        assert result[0]["name"] == "Security"
+        mock_client.list_resources.assert_called_once_with("swimlanes", project_id=9)
+
+    def test_create_swimlane(self, session_setup):
+        """Test create_swimlane POSTs project + name to /swimlanes."""
+        session_id, mock_client = session_setup
+        mock_client.api.post.return_value = {
+            "id": 1,
+            "name": "Security",
+            "project": 9,
+            "order": 100,
+        }
+        result = src.server.create_swimlane(9, "Security", session_id=session_id)
+        mock_client.api.post.assert_called_once_with(
+            "/swimlanes", json={"project": 9, "name": "Security"}
+        )
+        assert result["id"] == 1
+        assert result["name"] == "Security"
+
+    def test_create_swimlane_empty_name_raises(self, session_setup):
+        """Test create_swimlane raises on empty name before any API call."""
+        session_id, mock_client = session_setup
+        with pytest.raises(ValueError, match="Swimlane requires a non-empty name"):
+            src.server.create_swimlane(9, "", session_id=session_id)
+        mock_client.api.post.assert_not_called()
+
+    def test_get_swimlane(self, session_setup):
+        """Test get_swimlane GETs /swimlanes/{id}."""
+        session_id, mock_client = session_setup
+        mock_client.api.get.return_value = {"id": 1, "name": "Security", "project": 9, "order": 100}
+        result = src.server.get_swimlane(1, session_id)
+        mock_client.api.get.assert_called_once_with("/swimlanes/1")
+        assert result["id"] == 1
+
+    def test_update_swimlane(self, session_setup):
+        """Test update_swimlane PATCHes /swimlanes/{id} with parsed kwargs (no version handling)."""
+        session_id, mock_client = session_setup
+        mock_client.api.patch.return_value = {
+            "id": 1,
+            "name": "Security renamed",
+            "project": 9,
+            "order": 100,
+        }
+        result = src.server.update_swimlane(1, '{"name": "Security renamed"}', session_id)
+        mock_client.api.patch.assert_called_once_with(
+            "/swimlanes/1", json={"name": "Security renamed"}
+        )
+        assert result["name"] == "Security renamed"
+
+    def test_update_swimlane_no_kwargs_raises(self, session_setup):
+        """Test update_swimlane with no kwargs raises ValueError before any API call."""
+        session_id, mock_client = session_setup
+        with pytest.raises(ValueError, match="no fields to update"):
+            src.server.update_swimlane(1, "{}", session_id)
+        mock_client.api.patch.assert_not_called()
+
+    def test_update_swimlane_strips_unknown_kwargs(self, session_setup):
+        """Test update_swimlane drops kwargs not in ALLOWED_KWARGS['swimlane']."""
+        session_id, mock_client = session_setup
+        mock_client.api.patch.return_value = {"id": 1, "name": "Security", "project": 9, "order": 5}
+        src.server.update_swimlane(
+            1, '{"name": "Security", "statuses": "ignored", "project": "ignored"}', session_id
+        )
+        sent = mock_client.api.patch.call_args[1]["json"]
+        assert sent == {"name": "Security"}, f"unexpected payload: {sent}"
+
+    def test_delete_swimlane(self, session_setup):
+        """Test delete_swimlane DELETEs /swimlanes/{id} without move_to."""
+        session_id, mock_client = session_setup
+        mock_client.api.delete.return_value = None
+        result = src.server.delete_swimlane(1, session_id=session_id)
+        mock_client.api.delete.assert_called_once_with("/swimlanes/1")
+        assert result["status"] == "deleted"
+        assert result["swimlane_id"] == 1
+        assert result["moved_to"] is None
+
+    def test_delete_swimlane_with_move_to(self, session_setup):
+        """Test delete_swimlane appends ?moveTo= when migrating user stories."""
+        session_id, mock_client = session_setup
+        mock_client.api.delete.return_value = None
+        result = src.server.delete_swimlane(1, move_to=2, session_id=session_id)
+        mock_client.api.delete.assert_called_once_with("/swimlanes/1?moveTo=2")
+        assert result["moved_to"] == 2
+
+    def test_user_story_swimlane_kwarg_passes_through(self, session_setup):
+        """Adding 'swimlane' to ALLOWED_KWARGS['user_story'] enables update_user_story assignment."""
+        session_id, mock_client = session_setup
+        mock_client.api.user_stories.get.return_value = {"id": 805, "version": 3}
+        mock_client.api.user_stories.edit.return_value = {"id": 805, "swimlane": 1, "version": 4}
+        src.server.update_user_story(805, '{"swimlane": 1}', session_id)
+        mock_client.api.user_stories.edit.assert_called_once_with(
+            user_story_id=805, version=3, swimlane=1
+        )
+
     # ─── User management tools tests ─────────────────────────────────
 
     def test_get_project_members(self, session_setup):
@@ -2483,6 +2587,41 @@ class TestTaigaTools:
         with pytest.raises(ValueError, match="bulk_stories list cannot be empty"):
             src.server.bulk_update_user_story_milestone(21, 5, [])
 
+    def test_bulk_update_user_story_swimlane(self, session_setup):
+        """Test bulk_update_user_story_swimlane POSTs to bulk_update_kanban_order with swimlane_id."""
+        session_id, mock_client = session_setup
+        mock_client.api.post.return_value = [
+            {"id": 805, "swimlane": 1, "status": 97, "kanban_order": 1},
+            {"id": 806, "swimlane": 1, "status": 97, "kanban_order": 2},
+        ]
+        result = src.server.bulk_update_user_story_swimlane(
+            project_id=9,
+            status_id=97,
+            swimlane_id=1,
+            user_story_ids=[805, 806],
+            session_id=session_id,
+        )
+        mock_client.api.post.assert_called_once_with(
+            "/userstories/bulk_update_kanban_order",
+            json={
+                "project_id": 9,
+                "status_id": 97,
+                "swimlane_id": 1,
+                "bulk_userstories": [805, 806],
+            },
+        )
+        assert result["status"] == "updated"
+        assert result["stories_moved"] == 2
+        assert result["swimlane_id"] == 1
+        assert result["status_id"] == 97
+
+    def test_bulk_update_user_story_swimlane_empty_raises(self):
+        """Test bulk_update_user_story_swimlane raises on empty list before any API call."""
+        with pytest.raises(ValueError, match="user_story_ids list cannot be empty"):
+            src.server.bulk_update_user_story_swimlane(
+                project_id=9, status_id=97, swimlane_id=1, user_story_ids=[]
+            )
+
     def test_bulk_update_user_story_order_backlog(self, session_setup):
         """Test bulk_update_user_story_order with backlog order type."""
         session_id, mock_client = session_setup
@@ -2592,9 +2731,15 @@ class TestResponseFiltering:
     """Tests for the response filtering functionality."""
 
     def test_filter_standard_always_includes_version(self):
-        """version is required for updates in standard level."""
+        """version is required for updates in standard level.
+
+        Exceptions: member (read-only, no update endpoint) and swimlane
+        (Taiga API does not use optimistic concurrency on /swimlanes —
+        empirically no version field on the resource, see issue #24).
+        """
+        no_version = {"member", "swimlane"}
         for resource_type, levels in src.server.RESPONSE_FIELDS.items():
-            if resource_type != "member":  # member doesn't have version
+            if resource_type not in no_version:
                 assert "version" in levels["standard"], (
                     f"{resource_type} missing version in standard"
                 )

--- a/uv.lock
+++ b/uv.lock
@@ -712,7 +712,7 @@ cli = [
 
 [[package]]
 name = "mcp-taiga-bridge"
-version = "1.14.4"
+version = "1.14.6"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },


### PR DESCRIPTION
## Summary

Closes #24.

Adds Kanban swimlane management to pytaiga-mcp. Implements the design agreed on the issue (scope B + C1):

**5 CRUD tools** — \`list_swimlanes\`, \`create_swimlane\`, \`get_swimlane\`, \`update_swimlane\`, \`delete_swimlane\`. The Taiga \`/swimlanes\` endpoint is undocumented in [docs.taiga.io/api.html](https://docs.taiga.io/api.html) but empirically works on Taiga 2.40+; this PR mirrors the existing milestone CRUD pattern.

**Single-US swimlane assignment via existing \`update_user_story\`** — adds \`swimlane\` to \`ALLOWED_KWARGS[\"user_story\"]\` so callers can do \`update_user_story(... kwargs={\"swimlane\": <id>})\`. The comment on #24 flagged that without this entry, the feature ships half-functional.

**\`bulk_update_user_story_swimlane\`** (scope C1) — wraps Taiga's \`/userstories/bulk_update_kanban_order\` endpoint, which the official docs don't mention but empirically accepts a \`swimlane_id\` field. Per-status atomic constraint: all user stories in a single call must share the given \`status_id\` (matches Taiga's Kanban-drag mental model). For mixed-status bulk reorgs, the LLM groups by status and calls the tool once per group.

## Taiga gotchas documented in tool descriptions

Two constraints surfaced during live probing — neither is in the Taiga docs, both bite real callers:

1. **First swimlane on a project becomes the permanent \"default\"** — once a project has any swimlane, the first one created is marked default by Taiga and cannot be deleted via any API call (\`The default swimlane cannot be deleted\`). Removing it requires admin UI access. Existing user stories are auto-assigned to the default at creation time. \`create_swimlane\` description warns about this.

2. **\`delete_swimlane\` requires \`move_to\` when the swimlane has user stories** — without it, Taiga rejects with \`Cannot set swimlane to None if there are available swimlanes\`. \`delete_swimlane\` accepts an optional \`move_to\` arg that maps to Taiga's \`?moveTo=\` query param.

## Tests

- 11 new unit tests across the 5 CRUD tools, the \`user_story.swimlane\` allowlist passthrough, and both \`delete_swimlane\` code paths (with/without \`move_to\`).
- Updated the global \`test_filter_standard_always_includes_version\` invariant: swimlane joins \`member\` in the no-version exemption list (Taiga doesn't use optimistic concurrency on \`/swimlanes\`, verified empirically — no \`version\` field on the resource).
- 306/306 unit tests pass; ruff check + format clean.

## Live verification

End-to-end against taiga.tetra-ai.fr (project 9):

- [x] \`list_swimlanes\` returns array (initially empty for project 9, then 2 after creates)
- [x] \`create_swimlane\` creates with auto-populated per-status configuration
- [x] \`get_swimlane\` returns the resource with embedded \`statuses\`
- [x] \`update_swimlane\` rename succeeds without optimistic-locking version
- [x] \`update_swimlane\` with empty kwargs raises ValueError before any API call
- [x] \`delete_swimlane\` with \`?moveTo=\` migrates US and succeeds (verified during recovery from a smoke-test mishap that exposed the default-swimlane gotcha — write-up in the issue conversation)
- [x] \`update_user_story\` swimlane kwarg passthrough — unit-tested only; the underlying \`update_user_story\` flow already worked, the change here is a one-line allowlist entry
- [x] \`bulk_update_user_story_swimlane\` — unit-tested only; the underlying endpoint was empirically verified during issue investigation (see #24 comment)

The two unchecked items were skipped end-to-end to avoid creating another permanent default swimlane on project 9 just to verify wrappers around already-proven endpoints.