### PR TITLE
chore(inspect.sh): replace hardcoded upstream-author path with generic placeholder

### DIFF
--- a/inspect.sh
+++ b/inspect.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 # Usage examples:
 # stdio mode: 
-#   npx -y @modelcontextprotocol/inspector uv --directory /Users/talhaorak/Codes/pyTaigaMCP2 run python src/server.py --mode stdio --log-level [DEBUG|INFO|ERROR](default INFO) --log-file <log filename. default server.log>
+#   npx -y @modelcontextprotocol/inspector uv --directory <path/to/pytaiga-mcp> run python src/server.py --mode stdio --log-level [DEBUG|INFO|ERROR](default INFO) --log-file <log filename. default server.log>
 # sse mode:
-#   npx -y @modelcontextprotocol/inspector uv --directory /Users/talhaorak/Codes/pyTaigaMCP2 run python src/server.py --mode sse --port 5001 --log-level [DEBUG|INFO|ERROR](default INFO) --log-file <log filename. default server.log>
+#   npx -y @modelcontextprotocol/inspector uv --directory <path/to/pytaiga-mcp> run python src/server.py --mode sse --port 5001 --log-level [DEBUG|INFO|ERROR](default INFO) --log-file <log filename. default server.log>
 
 
 # Help/usage function


### PR DESCRIPTION
## Summary

Lines 4 and 6 of `inspect.sh` referenced `/Users/talhaorak/Codes/pyTaigaMCP2` — the original upstream author's local Mac filesystem path. Inherited unchanged when this repo was forked into the `TETRA-2023` org and never sanitized.

## Why fix

- The example commands serve as copy-paste material in the help comments, so they should reference a generic path the reader can substitute.
- Hardcoding one specific person's dev directory layout is mildly weird in a public repo.

## Change

Replaced both occurrences with `<path/to/pytaiga-mcp>`. Two-line diff, no functional impact (the comments are usage examples, not executed code).

## Test plan

- [x] `grep -n talhaorak inspect.sh` → no matches.
- [x] No functional code changed; CI lint/test workflows are unaffected.

`chore:` commit type — semrel will not bump a version.