### PR TITLE
fix(deps): bump GitPython 3.1.46 -> 3.1.50 to patch CVEs

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -413,14 +413,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.46"
+version = "3.1.50"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/b5/59d16470a1f0dfe8c793f9ef56fd3826093fc52b3bd96d6b9d6c26c7e27b/gitpython-3.1.46.tar.gz", hash = "sha256:400124c7d0ef4ea03f7310ac2fbf7151e09ff97f2a3288d64a440c584a29c37f", size = 215371, upload-time = "2026-01-01T15:37:32.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798, upload-time = "2026-05-06T04:01:26.571Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/09/e21df6aef1e1ffc0c816f0522ddc3f6dcded766c3261813131c78a704470/gitpython-3.1.46-py3-none-any.whl", hash = "sha256:79812ed143d9d25b6d176a10bb511de0f9c67b1fa641d82097b0ab90398a2058", size = 208620, upload-time = "2026-01-01T15:37:30.574Z" },
+    { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", size = 212507, upload-time = "2026-05-06T04:01:23.799Z" },
 ]
 
 [[package]]
@@ -712,7 +712,7 @@ cli = [
 
 [[package]]
 name = "mcp-taiga-bridge"
-version = "1.14.6"
+version = "1.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },


### PR DESCRIPTION
## Summary
- Bumps GitPython from 3.1.46 → 3.1.50 to resolve two open high-severity Dependabot alerts.
- Lockfile-only change: GitPython is a transitive dep via `python-semantic-release` (release tooling, not runtime), so no `pyproject.toml` change is needed.
- Also catches up the editable `mcp-taiga-bridge` entry (1.14.6 → 1.15.0) which was stale on master after the v1.15.0 release commit.

## Advisories
| Alert | Severity | GHSA | Summary |
|---|---|---|---|
| #19 | high | [GHSA-rpm5-65cw-6hj4](https://github.com/advisories/GHSA-rpm5-65cw-6hj4) | Command injection via Git options bypass |
| #20 | high | [GHSA-x2qx-6953-8485](https://github.com/advisories/GHSA-x2qx-6953-8485) | Unsafe option check validates `multi_options` before `shlex.split` |

Both are patched in GitPython >= 3.1.47.

## Test plan
- [x] `uv lock --upgrade-package gitpython` resolves cleanly (79 packages, no other churn)
- [x] Pre-commit unit tests pass
- [ ] Dependabot alerts #19 and #20 auto-close on merge to master