### PR TITLE
chore: add gitleaks to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,9 @@
 repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.6
     hooks:


### PR DESCRIPTION
## Summary
- Adds the [gitleaks](https://github.com/gitleaks/gitleaks) pre-commit hook (pinned at v8.30.1) ahead of ruff and the unit-test hook.
- Mirrors the setup already in use in `mcp/langfuse-mcp` so the MCP repos stay consistent.
- No `.gitleaks.toml` / `.gitleaksignore` needed — default ruleset is clean against this repo.

## Test plan
- [x] `pre-commit run gitleaks --all-files` passes against the full tracked tree
- [x] Local pre-commit (gitleaks + ruff + pytest) passes on the commit itself
- [ ] CI green on master after merge