### PR TITLE
fix: list_user_stories silently drops swimlane filter (upstream taiga-back typo)

### DIFF
--- a/src/taiga_client.py
+++ b/src/taiga_client.py
@@ -117,5 +117,14 @@ class TaigaClientWrapper:
         if project_id is not None:
             params["project"] = project_id
         params.update(filters)
+        # Workaround for upstream taiga-back typo (TETRA-2023/pytaiga-mcp#68):
+        # SwimlanesFilter declares param_name="swimnlane" (extra 'n'), so the
+        # back-end ignores ?swimlane= and only honours ?swimnlane=. Sending
+        # both keys keeps us correct before and after upstream fixes the typo,
+        # since the dispatcher uses whichever it recognises and ignores the
+        # other. Scoped to user_stories list — only that endpoint has the bug.
+        # Ref: taiga/projects/userstories/filters.py#L31-L34
+        if resource_type == "user_stories" and "swimlane" in params and "swimnlane" not in params:
+            params["swimnlane"] = params["swimlane"]
         result = self.api.get(endpoint, params=params, headers=_NO_PAGINATION_HEADERS)
         return result if isinstance(result, list) else []

--- a/src/taiga_client.py
+++ b/src/taiga_client.py
@@ -123,7 +123,9 @@ class TaigaClientWrapper:
         # both keys keeps us correct before and after upstream fixes the typo,
         # since the dispatcher uses whichever it recognises and ignores the
         # other. Scoped to user_stories list — only that endpoint has the bug.
-        # Ref: taiga/projects/userstories/filters.py#L31-L34
+        # Upstream ref:
+        # https://github.com/taigaio/taiga-back/blob/df14a4bdaee662962e343e3c4cd3fcd6a1339de7/taiga/projects/userstories/filters.py#L31-L34
+        # exclude_swimlane is unaffected (no typo there) and intentionally not translated.
         if resource_type == "user_stories" and "swimlane" in params and "swimnlane" not in params:
             params["swimnlane"] = params["swimlane"]
         result = self.api.get(endpoint, params=params, headers=_NO_PAGINATION_HEADERS)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3127,6 +3127,55 @@ class TestTaigaClientWrapper:
         )
         assert result == [{"id": 1}]
 
+    def test_list_resources_user_stories_swimlane_dual_emit(self):
+        """Test list_resources sends both 'swimlane' and 'swimnlane' for user_stories.
+
+        Workaround for upstream taiga-back typo (#68): SwimlanesFilter declares
+        param_name="swimnlane" so ?swimlane= is silently ignored by the backend.
+        """
+        wrapper = TaigaClientWrapper(host="http://test:9000")
+        wrapper.api = MagicMock()
+        wrapper.api.auth_token = "test-token"
+        wrapper.api.get.return_value = []
+        wrapper.list_resources("user_stories", project_id=9, swimlane=17)
+        call_params = wrapper.api.get.call_args[1]["params"]
+        assert call_params["swimlane"] == 17
+        assert call_params["swimnlane"] == 17
+        assert call_params["project"] == 9
+
+    def test_list_resources_user_stories_no_swimlane_unchanged(self):
+        """Test list_resources does not inject 'swimnlane' when no 'swimlane' filter."""
+        wrapper = TaigaClientWrapper(host="http://test:9000")
+        wrapper.api = MagicMock()
+        wrapper.api.auth_token = "test-token"
+        wrapper.api.get.return_value = []
+        wrapper.list_resources("user_stories", project_id=9, status=65)
+        call_params = wrapper.api.get.call_args[1]["params"]
+        assert "swimnlane" not in call_params
+        assert "swimlane" not in call_params
+
+    def test_list_resources_user_stories_swimnlane_explicit_preserved(self):
+        """Test caller-supplied 'swimnlane' is not overwritten by translation."""
+        wrapper = TaigaClientWrapper(host="http://test:9000")
+        wrapper.api = MagicMock()
+        wrapper.api.auth_token = "test-token"
+        wrapper.api.get.return_value = []
+        wrapper.list_resources("user_stories", project_id=9, swimlane=17, swimnlane=99)
+        call_params = wrapper.api.get.call_args[1]["params"]
+        assert call_params["swimlane"] == 17
+        assert call_params["swimnlane"] == 99
+
+    def test_list_resources_other_resource_swimlane_not_translated(self):
+        """Test 'swimlane' filter on non-user_stories endpoints is not translated."""
+        wrapper = TaigaClientWrapper(host="http://test:9000")
+        wrapper.api = MagicMock()
+        wrapper.api.auth_token = "test-token"
+        wrapper.api.get.return_value = []
+        wrapper.list_resources("tasks", project_id=9, swimlane=17)
+        call_params = wrapper.api.get.call_args[1]["params"]
+        assert call_params["swimlane"] == 17
+        assert "swimnlane" not in call_params
+
     def test_list_resources_no_project_id(self):
         """Test list_resources omits project key when project_id is None."""
         wrapper = TaigaClientWrapper(host="http://test:9000")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3176,6 +3176,19 @@ class TestTaigaClientWrapper:
         assert call_params["swimlane"] == 17
         assert "swimnlane" not in call_params
 
+    def test_list_resources_user_stories_exclude_swimlane_not_translated(self):
+        """Test 'exclude_swimlane' is passed through unchanged (no upstream typo there)."""
+        wrapper = TaigaClientWrapper(host="http://test:9000")
+        wrapper.api = MagicMock()
+        wrapper.api.auth_token = "test-token"
+        wrapper.api.get.return_value = []
+        wrapper.list_resources("user_stories", project_id=9, exclude_swimlane=17)
+        call_params = wrapper.api.get.call_args[1]["params"]
+        assert call_params["exclude_swimlane"] == 17
+        assert "exclude_swimnlane" not in call_params
+        assert "swimlane" not in call_params
+        assert "swimnlane" not in call_params
+
     def test_list_resources_no_project_id(self):
         """Test list_resources omits project key when project_id is None."""
         wrapper = TaigaClientWrapper(host="http://test:9000")

--- a/uv.lock
+++ b/uv.lock
@@ -712,7 +712,7 @@ cli = [
 
 [[package]]
 name = "mcp-taiga-bridge"
-version = "1.15.0"
+version = "1.15.1"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },


### PR DESCRIPTION
Closes #68.

## Summary

Workaround for a 5-year-old upstream typo in `taigaio/taiga-back` that makes the `swimlane` filter on `GET /api/v1/userstories` silently no-op. Inside `taiga_client.py:list_resources`, when `resource_type=="user_stories"` and the caller passed `swimlane`, also emit `swimnlane` — so the back-end's misspelled `param_name` matches and the filter actually applies. Sending both keys keeps us correct before *and* after upstream fixes the typo (the dispatcher uses whichever it recognises and ignores the other).

See #68 for the full reproduction, root-cause investigation with permalinks to `taiga/projects/userstories/filters.py#L31-L34`, and design rationale.

## The change

```diff
+        # Workaround for upstream taiga-back typo (TETRA-2023/pytaiga-mcp#68):
+        # SwimlanesFilter declares param_name="swimnlane" (extra 'n'), so the
+        # back-end ignores ?swimlane= and only honours ?swimnlane=. Sending
+        # both keys keeps us correct before and after upstream fixes the typo,
+        # since the dispatcher uses whichever it recognises and ignores the
+        # other. Scoped to user_stories list — only that endpoint has the bug.
+        # Ref: taiga/projects/userstories/filters.py#L31-L34
+        if resource_type == "user_stories" and "swimlane" in params and "swimnlane" not in params:
+            params["swimnlane"] = params["swimlane"]
```

Scope:
- `user_stories` list endpoint only — no other Taiga resource has this bug.
- Caller-supplied `swimnlane` is preserved (translation only fills it when absent), so a caller can still target the misspelled key directly without being overwritten.
- `exclude_swimlane` is unaffected (no typo there in upstream).
- Body-payload uses of `swimlane` (e.g. `update_user_story(kwargs={"swimlane": id})`) are unaffected — those don't go through query-param land.

## Tests

4 new unit tests in `TestTaigaClientWrapper`:

- `test_list_resources_user_stories_swimlane_dual_emit` — both keys are sent.
- `test_list_resources_user_stories_no_swimlane_unchanged` — no `swimnlane` injected when caller didn't pass `swimlane`.
- `test_list_resources_user_stories_swimnlane_explicit_preserved` — explicit `swimnlane` not overwritten.
- `test_list_resources_other_resource_swimlane_not_translated` — the translation is scoped strictly to `user_stories`.

All 312 existing unit tests still pass. Pre-commit (secrets / ruff / ruff format / unit tests) green.

## Test plan

- [x] `uv run pytest tests/test_server.py` — 312 passed
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] Workaround confirmed end-to-end against `taigaio/taiga-back:latest` during the investigation (#68): direct `?swimnlane=17` returns the expected 15-US subset on TETRA project #9 / swimlane #17, while `?swimlane=17` returns the full ~150 USs.
- [ ] Optional integration test (gated on `TAIGA_API_URL`) deferred to a follow-up — would create a project with ≥2 swimlanes and assert filtering works end-to-end through the MCP tool. The current unit tests verify the params dict construction; the back-end behaviour is verified manually.