### PR TITLE
fix(deps): Bump python-multipart 0.0.26 -> 0.0.27 to patch DoS CVE

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -712,7 +712,7 @@ cli = [
 
 [[package]]
 name = "mcp-taiga-bridge"
-version = "1.15.1"
+version = "1.15.2"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },
@@ -1102,11 +1102,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.26"
+version = "0.0.27"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/9b/f23807317a113dc36e74e75eb265a02dd1a4d9082abc3c1064acd22997c4/python_multipart-0.0.27.tar.gz", hash = "sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602", size = 44043, upload-time = "2026-04-27T10:51:26.649Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
+    { url = "https://files.pythonhosted.org/packages/99/78/4126abcbdbd3c559d43e0db7f7b9173fc6befe45d39a2856cc0b8ec2a5a6/python_multipart-0.0.27-py3-none-any.whl", hash = "sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645", size = 29254, upload-time = "2026-04-27T10:51:24.997Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes Dependabot alert [#21](https://github.com/TETRA-2023/pytaiga-mcp/security/dependabot/21).

## Summary

- [`GHSA-pp6c-gr5w-3c5g`](https://github.com/advisories/GHSA-pp6c-gr5w-3c5g) (severity: **high**) — `python-multipart < 0.0.27` is vulnerable to a denial-of-service via unbounded multipart part headers. First patched in `0.0.27`.
- Transitive dep via `mcp[cli]` (Starlette / Uvicorn ingress used for SSE / HTTP MCP transports). pytaiga-mcp ships stdio by default, but the package is loaded in any deployment that enables `--sse` or `--streamable-http`, so a hostile client could DoS the MCP process.
- **Lock-only change** — no `pyproject.toml` edit needed; the version is constrained transitively. `uv lock --upgrade-package python-multipart` produced a clean delta (`0.0.26` → `0.0.27` plus an editable-self bump from the just-released `1.15.2`).

## Test plan

- [x] `uv lock --upgrade-package python-multipart` — diff is exactly the targeted package.
- [x] `uv sync --extra dev` — clean install on bumped lock.
- [x] `uv run pytest tests/test_server.py` — 313/313 passing.
- [x] `uv run ruff check src/ tests/` — n/a (no source changes).
- [x] Pre-commit hooks (secrets / ruff / format / unit tests) — green.