### PR TITLE
feat: add task tools to workflow mode (create/update/set_status/break_down)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ MCP (Model Context Protocol) server bridging AI assistants with the Taiga projec
 
 | Mode | Entry point | Tools | Use when |
 |---|---|---|---|
-| `workflow` (default) | `src/server_workflow.py` | ~23 intent tools | Everyday project management: sprint planning, backlog grooming, team workload |
+| `workflow` (default) | `src/server_workflow.py` | ~27 intent tools | Everyday project management: sprint planning, backlog grooming, team workload, task breakdown |
 | `full` | `src/server_full.py` | 107 CRUD tools | Automation scripts, admin tasks, full API access |
 
 Select mode via `TAIGA_SERVER_MODE=workflow` (default) or `TAIGA_SERVER_MODE=full`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ MCP (Model Context Protocol) server bridging AI assistants with the Taiga projec
 
 | Mode | Entry point | Tools | Use when |
 |---|---|---|---|
-| `workflow` (default) | `src/server_workflow.py` | ~27 intent tools | Everyday project management: sprint planning, backlog grooming, team workload, task breakdown |
+| `workflow` (default) | `src/server_workflow.py` | ~28 intent tools | Everyday project management: sprint planning, backlog grooming, team workload, task breakdown |
 | `full` | `src/server_full.py` | 107 CRUD tools | Automation scripts, admin tasks, full API access |
 
 Select mode via `TAIGA_SERVER_MODE=workflow` (default) or `TAIGA_SERVER_MODE=full`.
@@ -20,7 +20,7 @@ Select mode via `TAIGA_SERVER_MODE=workflow` (default) or `TAIGA_SERVER_MODE=ful
 
 ```
 src/
-  server_workflow.py — Workflow/intent tools (~27, intent-based)
+  server_workflow.py — Workflow/intent tools (~28, intent-based)
   server_full.py     — Full CRUD tools (107, all Taiga API endpoints)
   taiga_client.py    — TaigaClientWrapper: auth, raw API calls, pagination bypass
   config.py          — Pydantic settings (env vars, SecretStr credentials)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ Select mode via `TAIGA_SERVER_MODE=workflow` (default) or `TAIGA_SERVER_MODE=ful
 
 ```
 src/
-  server_workflow.py — Workflow/intent tools (~23, v2.0+)
+  server_workflow.py — Workflow/intent tools (~27, intent-based)
   server_full.py     — Full CRUD tools (107, all Taiga API endpoints)
   taiga_client.py    — TaigaClientWrapper: auth, raw API calls, pagination bypass
   config.py          — Pydantic settings (env vars, SecretStr credentials)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The bridge ships two servers in a single image. Select one at runtime via the `T
 
 | Mode | Tools | Best for |
 |---|---|---|
-| `workflow` (default) | ~27 intent tools | Product Owners and team members managing projects daily |
+| `workflow` (default) | ~28 intent tools | Product Owners and team members managing projects daily |
 | `full` | 107 CRUD tools | Automation scripts, admin tasks, full API access |
 
 **Workflow mode** (default) accepts human-readable names everywhere — project slug, sprint name, status name, username — and resolves them internally. One call to `get_sprint_board` returns a complete board view with all stories and tasks; `plan_sprint` creates a sprint and assigns stories in a single step.
@@ -51,7 +51,7 @@ TAIGA_SERVER_MODE=full ./run.sh
 
 ## Features
 
-### Workflow mode tools (~27)
+### Workflow mode tools (~28)
 
 Intent-based tools that resolve names and composite API calls:
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ By using the MCP standard, this bridge allows AI systems to maintain contextual 
 
 ## Two server modes
 
-Starting with v2.0, this bridge ships two servers in a single image. Select one at runtime via the `TAIGA_SERVER_MODE` environment variable:
+The bridge ships two servers in a single image. Select one at runtime via the `TAIGA_SERVER_MODE` environment variable:
 
 | Mode | Tools | Best for |
 |---|---|---|

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Starting with v2.0, this bridge ships two servers in a single image. Select one 
 
 | Mode | Tools | Best for |
 |---|---|---|
-| `workflow` (default) | ~23 intent tools | Product Owners and team members managing projects daily |
+| `workflow` (default) | ~27 intent tools | Product Owners and team members managing projects daily |
 | `full` | 107 CRUD tools | Automation scripts, admin tasks, full API access |
 
 **Workflow mode** (default) accepts human-readable names everywhere — project slug, sprint name, status name, username — and resolves them internally. One call to `get_sprint_board` returns a complete board view with all stories and tasks; `plan_sprint` creates a sprint and assigns stories in a single step.
@@ -51,7 +51,7 @@ TAIGA_SERVER_MODE=full ./run.sh
 
 ## Features
 
-### Workflow mode tools (~23)
+### Workflow mode tools (~27)
 
 Intent-based tools that resolve names and composite API calls:
 
@@ -60,8 +60,13 @@ Intent-based tools that resolve names and composite API calls:
 | `get_project_overview` | Project snapshot: team, active sprint, story counts by status |
 | `browse_backlog` | Filtered backlog view with name-based filters (status, assignee, epic) |
 | `create_story` | Create US with optional epic link, sprint, assignee — one call |
-| `update_story` | Update any US field by name (status, assignee, sprint) |
+| `update_story` | Update any US field by name (status, assignee, sprint, epic) |
+| `create_task` | Add a single task under a user story |
+| `update_task` | Update a task by ref (status, assignee, sprint, reparent to another story) |
+| `set_task_status` | Change task status by name |
+| `break_down_story` | Decompose a story into multiple tasks in one call (bulk-aware) |
 | `create_issue` | Create issue with smart defaults for type/priority/severity |
+| `update_issue` | Update any issue field by name |
 | `get_sprint_board` | Full sprint view: all stories + tasks, summary by status |
 | `plan_sprint` | Create sprint + assign stories in one step |
 | `move_to_sprint` | Move stories by ref to a named sprint |

--- a/src/server_workflow.py
+++ b/src/server_workflow.py
@@ -1,6 +1,6 @@
 """Workflow-oriented Taiga MCP server.
 
-Exposes ~27 intent-based tools designed for everyday project management:
+Exposes ~28 intent-based tools designed for everyday project management:
 sprint planning, backlog grooming, team workload, epic tracking, task
 breakdown, wiki, and comments. All tools accept human-readable names
 (project slug, sprint name, status name, username) and resolve them to
@@ -875,7 +875,9 @@ def update_story(
     "create_task",
     description=(
         "Add a single task under an existing user story. story_ref is the parent US ref number. "
-        "All name fields are resolved (assignee username, status name). "
+        "By default the task inherits the parent story's sprint; pass sprint=<name|id> to "
+        "place the task in a different sprint, or sprint=0 to keep it out of any sprint. "
+        "All name fields are resolved (assignee username, status name, sprint name). "
         "project accepts slug or ID."
     ),
 )
@@ -886,6 +888,7 @@ def create_task(
     description: Optional[str] = None,
     status: Optional[str] = None,
     assignee: Optional[str] = None,
+    sprint: Optional[Any] = None,
     due_date: Optional[str] = None,
     tags: Optional[List[str]] = None,
     blocked: Optional[bool] = None,
@@ -903,7 +906,20 @@ def create_task(
             raise ValueError(f"User story #{story_ref} not found in project '{proj['slug']}'.")
 
         data: Dict[str, Any] = {"user_story": story["id"]}
-        # Tasks inherit their parent story's milestone by default; let Taiga handle it.
+
+        # Milestone handling: Taiga does NOT auto-copy the parent story's
+        # milestone onto a new task — Task and UserStory are independent FKs.
+        # We replicate the sprint-board UI behaviour by defaulting to the
+        # parent's milestone. Callers can override with sprint=<name|id> or
+        # explicitly opt out with sprint=0.
+        if sprint is None:
+            if story.get("milestone") is not None:
+                data["milestone"] = story["milestone"]
+        elif sprint == 0:
+            pass  # explicit "no sprint"
+        else:
+            data["milestone"] = _resolve_sprint(client, project_id, sprint)["id"]
+
         if description:
             data["description"] = description
         if tags:
@@ -995,15 +1011,29 @@ def update_task(
     return _execute_taiga_operation("update_task", do_update, f"task #{ref} in {project}")
 
 
+_TASK_OVERRIDE_KEYS = {
+    "subject",
+    "description",
+    "status",
+    "assignee",
+    "due_date",
+    "tags",
+    "blocked",
+}
+
+
 @mcp.tool(
     "break_down_story",
     description=(
         "Decompose a user story into multiple tasks in one call. tasks accepts a list of "
         "subject strings (e.g. ['design', 'API', 'tests']) or a list of dicts "
-        "({'subject': str, 'assignee': str?, 'status': str?, 'description': str?}) "
-        "for per-task field overrides. If the parent story is assigned to a sprint, "
-        "tasks are created in that sprint via Taiga's bulk endpoint; otherwise tasks "
-        "are created individually under the story. project accepts slug or ID."
+        "({'subject': str, 'assignee': str?, 'status': str?, 'description': str?, "
+        "'due_date': str?, 'tags': [str]?, 'blocked': bool?}) for per-task overrides. "
+        "Tasks inherit the parent story's sprint. Performance: when the story is in a "
+        "sprint AND no per-task overrides are provided, the bulk endpoint creates all "
+        "tasks in one API call; otherwise (story in backlog OR overrides present) tasks "
+        "are created individually. Unknown override keys raise ValueError. "
+        "project accepts slug or ID."
     ),
 )
 def break_down_story(
@@ -1025,26 +1055,30 @@ def break_down_story(
         if not story:
             raise ValueError(f"User story #{story_ref} not found in project '{proj['slug']}'.")
 
-        # Normalize: every entry becomes a dict with at least "subject".
+        # Normalize entries into dicts and validate override keys.
         normalized: List[Dict[str, Any]] = []
         for entry in tasks:
             if isinstance(entry, str):
                 normalized.append({"subject": entry})
             elif isinstance(entry, dict) and entry.get("subject"):
+                unknown = set(entry.keys()) - _TASK_OVERRIDE_KEYS
+                if unknown:
+                    raise ValueError(
+                        f"Unknown per-task override keys: {sorted(unknown)}. "
+                        f"Allowed: {sorted(_TASK_OVERRIDE_KEYS)}."
+                    )
                 normalized.append(entry)
             else:
                 raise ValueError(
                     "Each entry in tasks must be a non-empty string or a dict with a 'subject' key."
                 )
 
-        # Need per-task field overrides? Then we must create tasks individually
-        # because Taiga's /tasks/bulk_create only accepts a flat list of subjects.
-        # Otherwise, prefer the bulk endpoint when the parent is in a sprint.
+        # Bulk path requires sprint context AND no per-task overrides — Taiga's
+        # /tasks/bulk_create only accepts a flat subject list scoped to one milestone.
         has_overrides = any(set(e.keys()) - {"subject"} for e in normalized)
         milestone_id = story.get("milestone")
 
         if not has_overrides and milestone_id is not None:
-            # Sprint-scoped bulk path — single API call.
             bulk_tasks = "\n".join(e["subject"] for e in normalized)
             result = client.api.post(
                 "/tasks/bulk_create",
@@ -1055,15 +1089,30 @@ def break_down_story(
                     "us_id": story["id"],
                 },
             )
-            created = result if isinstance(result, list) else []
+            if isinstance(result, list):
+                created = result
+            else:
+                logger.warning(
+                    f"Unexpected /tasks/bulk_create response shape "
+                    f"({type(result).__name__}); reporting 0 created."
+                )
+                created = []
         else:
-            # Loop path: story is in backlog (no milestone) OR caller passed
-            # per-task overrides. Per-call create handles both.
+            # Loop path: story in backlog (no milestone) OR per-task overrides present.
+            # Tasks inherit the parent story's milestone when available.
             created = []
             for entry in normalized:
                 data: Dict[str, Any] = {"user_story": story["id"]}
+                if milestone_id is not None:
+                    data["milestone"] = milestone_id
                 if "description" in entry:
                     data["description"] = entry["description"]
+                if "due_date" in entry:
+                    data["due_date"] = entry["due_date"]
+                if "tags" in entry:
+                    data["tags"] = entry["tags"]
+                if "blocked" in entry:
+                    data["is_blocked"] = entry["blocked"]
                 if "status" in entry:
                     data["status"] = _resolve_status(
                         client, project_id, "task", entry["status"], actual_session_id

--- a/src/server_workflow.py
+++ b/src/server_workflow.py
@@ -213,6 +213,19 @@ _ISSUE_ATTR_RESOURCE_MAP = {
     "type": "issue_types",
 }
 
+# Allowed override keys for break_down_story per-task dicts. Kept aligned with
+# the kwargs surface of create_task. Adding a field to create_task should
+# update this set too.
+_TASK_OVERRIDE_KEYS = {
+    "subject",
+    "description",
+    "status",
+    "assignee",
+    "due_date",
+    "tags",
+    "blocked",
+}
+
 
 def _resolve_status(
     client: TaigaClientWrapper,
@@ -911,11 +924,14 @@ def create_task(
         # milestone onto a new task — Task and UserStory are independent FKs.
         # We replicate the sprint-board UI behaviour by defaulting to the
         # parent's milestone. Callers can override with sprint=<name|id> or
-        # explicitly opt out with sprint=0.
+        # explicitly opt out with sprint=0 (or "0" — both accepted).
+        # `str(sprint) == "0"` catches int 0 and string "0" without matching
+        # bool False (str(False) == "False"), which keeps the opt-out path
+        # honest about what counts as "no sprint".
         if sprint is None:
             if story.get("milestone") is not None:
                 data["milestone"] = story["milestone"]
-        elif sprint == 0:
+        elif str(sprint) == "0":
             pass  # explicit "no sprint"
         else:
             data["milestone"] = _resolve_sprint(client, project_id, sprint)["id"]
@@ -1009,17 +1025,6 @@ def update_task(
         return _task_summary(result)
 
     return _execute_taiga_operation("update_task", do_update, f"task #{ref} in {project}")
-
-
-_TASK_OVERRIDE_KEYS = {
-    "subject",
-    "description",
-    "status",
-    "assignee",
-    "due_date",
-    "tags",
-    "blocked",
-}
 
 
 @mcp.tool(

--- a/src/server_workflow.py
+++ b/src/server_workflow.py
@@ -1,9 +1,10 @@
 """Workflow-oriented Taiga MCP server.
 
-Exposes ~23 intent-based tools designed for everyday project management:
-sprint planning, backlog grooming, team workload, epic tracking, wiki, and
-comments. All tools accept human-readable names (project slug, sprint name,
-status name, username) and resolve them to API IDs internally.
+Exposes ~27 intent-based tools designed for everyday project management:
+sprint planning, backlog grooming, team workload, epic tracking, task
+breakdown, wiki, and comments. All tools accept human-readable names
+(project slug, sprint name, status name, username) and resolve them to
+API IDs internally.
 
 Start with:
     TAIGA_SERVER_MODE=workflow  (default)
@@ -865,6 +866,229 @@ def update_story(
     return _execute_taiga_operation("update_story", do_update, f"#{ref} in {project}")
 
 
+# ---------------------------------------------------------------------------
+# Task tools
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(
+    "create_task",
+    description=(
+        "Add a single task under an existing user story. story_ref is the parent US ref number. "
+        "All name fields are resolved (assignee username, status name). "
+        "project accepts slug or ID."
+    ),
+)
+def create_task(
+    project: Any,
+    story_ref: int,
+    subject: str,
+    description: Optional[str] = None,
+    status: Optional[str] = None,
+    assignee: Optional[str] = None,
+    due_date: Optional[str] = None,
+    tags: Optional[List[str]] = None,
+    blocked: Optional[bool] = None,
+    session_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    actual_session_id = _get_session_id(session_id)
+    client = _get_authenticated_client(actual_session_id)
+
+    def do_create():
+        proj = _resolve_project(client, project)
+        project_id = proj["id"]
+
+        story = client.api.user_stories.get_by_ref(ref=story_ref, project=project_id)
+        if not story:
+            raise ValueError(f"User story #{story_ref} not found in project '{proj['slug']}'.")
+
+        data: Dict[str, Any] = {"user_story": story["id"]}
+        # Tasks inherit their parent story's milestone by default; let Taiga handle it.
+        if description:
+            data["description"] = description
+        if tags:
+            data["tags"] = tags
+        if due_date:
+            data["due_date"] = due_date
+        if blocked is not None:
+            data["is_blocked"] = blocked
+        if status:
+            data["status"] = _resolve_status(client, project_id, "task", status, actual_session_id)
+        if assignee:
+            data["assigned_to"] = _resolve_user(client, project_id, assignee, actual_session_id)
+
+        result = client.api.tasks.create(project=project_id, subject=subject, data=data)
+        return {
+            "status": "created",
+            "ref": result.get("ref"),
+            "id": result.get("id"),
+            "subject": result.get("subject"),
+            "parent_story_ref": story_ref,
+        }
+
+    return _execute_taiga_operation("create_task", do_create, f"under US #{story_ref} in {project}")
+
+
+@mcp.tool(
+    "update_task",
+    description=(
+        "Update a task by its ref number. All fields are optional — only provided fields change. "
+        "status, assignee, and sprint are resolved by name. story_ref reparents the task to a "
+        "different user story. sprint accepts a name or ID; tasks can have a milestone "
+        "independent of their parent story. project accepts slug or ID."
+    ),
+)
+def update_task(
+    project: Any,
+    ref: int,
+    subject: Optional[str] = None,
+    description: Optional[str] = None,
+    status: Optional[str] = None,
+    assignee: Optional[str] = None,
+    sprint: Optional[Any] = None,
+    story_ref: Optional[int] = None,
+    blocked: Optional[bool] = None,
+    tags: Optional[List[str]] = None,
+    session_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    actual_session_id = _get_session_id(session_id)
+    client = _get_authenticated_client(actual_session_id)
+
+    def do_update():
+        proj = _resolve_project(client, project)
+        project_id = proj["id"]
+
+        current = client.api.tasks.get_by_ref(ref=ref, project=project_id)
+        if not current:
+            raise ValueError(f"Task #{ref} not found in project '{proj['slug']}'.")
+
+        payload: Dict[str, Any] = {"version": current["version"]}
+        if subject is not None:
+            payload["subject"] = subject
+        if description is not None:
+            payload["description"] = description
+        if status is not None:
+            payload["status"] = _resolve_status(
+                client, project_id, "task", status, actual_session_id
+            )
+        if assignee is not None:
+            payload["assigned_to"] = _resolve_user(client, project_id, assignee, actual_session_id)
+        if sprint is not None:
+            milestone = _resolve_sprint(client, project_id, sprint)
+            payload["milestone"] = milestone["id"]
+        if story_ref is not None:
+            new_story = client.api.user_stories.get_by_ref(ref=story_ref, project=project_id)
+            if not new_story:
+                raise ValueError(f"User story #{story_ref} not found in project '{proj['slug']}'.")
+            payload["user_story"] = new_story["id"]
+        if blocked is not None:
+            payload["is_blocked"] = blocked
+        if tags is not None:
+            payload["tags"] = tags
+
+        if len(payload) == 1:  # only version key
+            raise ValueError("No fields to update were provided.")
+
+        result = client.api.tasks.edit(current["id"], **payload)
+        return _task_summary(result)
+
+    return _execute_taiga_operation("update_task", do_update, f"task #{ref} in {project}")
+
+
+@mcp.tool(
+    "break_down_story",
+    description=(
+        "Decompose a user story into multiple tasks in one call. tasks accepts a list of "
+        "subject strings (e.g. ['design', 'API', 'tests']) or a list of dicts "
+        "({'subject': str, 'assignee': str?, 'status': str?, 'description': str?}) "
+        "for per-task field overrides. If the parent story is assigned to a sprint, "
+        "tasks are created in that sprint via Taiga's bulk endpoint; otherwise tasks "
+        "are created individually under the story. project accepts slug or ID."
+    ),
+)
+def break_down_story(
+    project: Any,
+    story_ref: int,
+    tasks: List[Any],
+    session_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    if not tasks:
+        raise ValueError("tasks list cannot be empty.")
+    actual_session_id = _get_session_id(session_id)
+    client = _get_authenticated_client(actual_session_id)
+
+    def do_break_down():
+        proj = _resolve_project(client, project)
+        project_id = proj["id"]
+
+        story = client.api.user_stories.get_by_ref(ref=story_ref, project=project_id)
+        if not story:
+            raise ValueError(f"User story #{story_ref} not found in project '{proj['slug']}'.")
+
+        # Normalize: every entry becomes a dict with at least "subject".
+        normalized: List[Dict[str, Any]] = []
+        for entry in tasks:
+            if isinstance(entry, str):
+                normalized.append({"subject": entry})
+            elif isinstance(entry, dict) and entry.get("subject"):
+                normalized.append(entry)
+            else:
+                raise ValueError(
+                    "Each entry in tasks must be a non-empty string or a dict with a 'subject' key."
+                )
+
+        # Need per-task field overrides? Then we must create tasks individually
+        # because Taiga's /tasks/bulk_create only accepts a flat list of subjects.
+        # Otherwise, prefer the bulk endpoint when the parent is in a sprint.
+        has_overrides = any(set(e.keys()) - {"subject"} for e in normalized)
+        milestone_id = story.get("milestone")
+
+        if not has_overrides and milestone_id is not None:
+            # Sprint-scoped bulk path — single API call.
+            bulk_tasks = "\n".join(e["subject"] for e in normalized)
+            result = client.api.post(
+                "/tasks/bulk_create",
+                json={
+                    "project_id": project_id,
+                    "bulk_tasks": bulk_tasks,
+                    "milestone_id": milestone_id,
+                    "us_id": story["id"],
+                },
+            )
+            created = result if isinstance(result, list) else []
+        else:
+            # Loop path: story is in backlog (no milestone) OR caller passed
+            # per-task overrides. Per-call create handles both.
+            created = []
+            for entry in normalized:
+                data: Dict[str, Any] = {"user_story": story["id"]}
+                if "description" in entry:
+                    data["description"] = entry["description"]
+                if "status" in entry:
+                    data["status"] = _resolve_status(
+                        client, project_id, "task", entry["status"], actual_session_id
+                    )
+                if "assignee" in entry:
+                    data["assigned_to"] = _resolve_user(
+                        client, project_id, entry["assignee"], actual_session_id
+                    )
+                task = client.api.tasks.create(
+                    project=project_id, subject=entry["subject"], data=data
+                )
+                created.append(task)
+
+        return {
+            "status": "decomposed",
+            "story_ref": story_ref,
+            "tasks_created": len(created),
+            "tasks": [{"ref": t.get("ref"), "subject": t.get("subject")} for t in created],
+        }
+
+    return _execute_taiga_operation(
+        "break_down_story", do_break_down, f"US #{story_ref} in {project}"
+    )
+
+
 @mcp.tool(
     "create_issue",
     description=(
@@ -1237,6 +1461,41 @@ def set_story_status(
         }
 
     return _execute_taiga_operation("set_story_status", do_set, f"#{ref} in {project}")
+
+
+@mcp.tool(
+    "set_task_status",
+    description=(
+        "Change the status of a task by its ref number using the status name "
+        "(e.g. 'In Progress', 'Done'). project accepts slug or ID."
+    ),
+)
+def set_task_status(
+    project: Any,
+    ref: int,
+    status: str,
+    session_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    actual_session_id = _get_session_id(session_id)
+    client = _get_authenticated_client(actual_session_id)
+
+    def do_set():
+        proj = _resolve_project(client, project)
+        project_id = proj["id"]
+        status_id = _resolve_status(client, project_id, "task", status, actual_session_id)
+
+        current = client.api.tasks.get_by_ref(ref=ref, project=project_id)
+        if not current:
+            raise ValueError(f"Task #{ref} not found in project '{proj['slug']}'.")
+
+        result = client.api.tasks.edit(current["id"], status=status_id, version=current["version"])
+        return {
+            "ref": ref,
+            "status": (result.get("status_extra_info") or {}).get("name") or status,
+            "is_closed": result.get("is_closed", False),
+        }
+
+    return _execute_taiga_operation("set_task_status", do_set, f"task #{ref} in {project}")
 
 
 @mcp.tool(

--- a/tests/test_server_workflow.py
+++ b/tests/test_server_workflow.py
@@ -957,3 +957,53 @@ class TestBreakDownStoryOverrides:
         )
         data = mock_client.api.tasks.create.call_args.kwargs["data"]
         assert data["milestone"] == 99
+
+
+# ---------------------------------------------------------------------------
+# Regression: round-2 review polish on PR #73
+# ---------------------------------------------------------------------------
+
+
+class TestCreateTaskSprintOptOutString:
+    """The opt-out branch must accept both int 0 and string "0"."""
+
+    def _project(self):
+        return {"id": 1, "slug": "p", "name": "P"}
+
+    def test_sprint_string_zero_opts_out(self, session, mock_client):
+        mock_client.api.get.return_value = self._project()
+        mock_client.api.user_stories.get_by_ref.return_value = {
+            "id": 50,
+            "ref": 42,
+            "milestone": 99,
+        }
+        mock_client.api.tasks.create.return_value = {"id": 1, "ref": 1, "subject": "X"}
+        wf.create_task("p", 42, "X", sprint="0", session_id=session)
+        data = mock_client.api.tasks.create.call_args.kwargs["data"]
+        # str "0" must opt out, NOT fall through to _resolve_sprint(..., "0")
+        # which would look up a non-existent milestone.
+        assert "milestone" not in data
+        mock_client.list_resources.assert_not_called()
+
+
+class TestBreakDownStoryBulkShapeWarn:
+    """Bulk endpoint returning a non-list should warn and coerce to []."""
+
+    def test_warns_and_coerces_on_dict_response(self, session, mock_client, caplog):
+        mock_client.api.get.return_value = {"id": 1, "slug": "p", "name": "P"}
+        mock_client.api.user_stories.get_by_ref.return_value = {
+            "id": 50,
+            "ref": 42,
+            "milestone": 33,
+        }
+        # Simulate an unexpected response shape from /tasks/bulk_create.
+        mock_client.api.post.return_value = {"unexpected": "shape"}
+
+        with caplog.at_level("WARNING", logger="src.server_workflow"):
+            result = wf.break_down_story("p", 42, ["X", "Y"], session_id=session)
+
+        assert result["tasks_created"] == 0
+        assert result["tasks"] == []
+        assert any(
+            "Unexpected /tasks/bulk_create response shape" in rec.message for rec in caplog.records
+        )

--- a/tests/test_server_workflow.py
+++ b/tests/test_server_workflow.py
@@ -835,3 +835,125 @@ class TestBreakDownStory:
         }
         with pytest.raises(ValueError, match="must be a non-empty string or a dict"):
             wf.break_down_story("p", 42, [{"no_subject": "oops"}], session_id=session)
+
+
+# ---------------------------------------------------------------------------
+# Regression: review round on PR #73
+# ---------------------------------------------------------------------------
+
+
+class TestCreateTaskSprintInheritance:
+    """Regression: create_task must default the task's milestone to the parent's."""
+
+    def _project(self):
+        return {"id": 1, "slug": "p", "name": "P"}
+
+    def test_inherits_parent_milestone_when_sprint_not_given(self, session, mock_client):
+        mock_client.api.get.return_value = self._project()
+        mock_client.api.user_stories.get_by_ref.return_value = {
+            "id": 50,
+            "ref": 42,
+            "milestone": 99,
+        }
+        mock_client.api.tasks.create.return_value = {"id": 1, "ref": 1, "subject": "X"}
+        wf.create_task("p", 42, "X", session_id=session)
+        data = mock_client.api.tasks.create.call_args.kwargs["data"]
+        # Critical: task lands in the parent story's sprint by default.
+        assert data["milestone"] == 99
+
+    def test_no_milestone_when_parent_in_backlog(self, session, mock_client):
+        mock_client.api.get.return_value = self._project()
+        mock_client.api.user_stories.get_by_ref.return_value = {
+            "id": 50,
+            "ref": 42,
+            "milestone": None,
+        }
+        mock_client.api.tasks.create.return_value = {"id": 1, "ref": 1, "subject": "X"}
+        wf.create_task("p", 42, "X", session_id=session)
+        data = mock_client.api.tasks.create.call_args.kwargs["data"]
+        assert "milestone" not in data
+
+    def test_sprint_zero_opts_out_even_if_parent_in_sprint(self, session, mock_client):
+        mock_client.api.get.return_value = self._project()
+        mock_client.api.user_stories.get_by_ref.return_value = {
+            "id": 50,
+            "ref": 42,
+            "milestone": 99,
+        }
+        mock_client.api.tasks.create.return_value = {"id": 1, "ref": 1, "subject": "X"}
+        wf.create_task("p", 42, "X", sprint=0, session_id=session)
+        data = mock_client.api.tasks.create.call_args.kwargs["data"]
+        assert "milestone" not in data
+
+    def test_explicit_sprint_overrides_parent(self, session, mock_client):
+        mock_client.api.get.return_value = self._project()
+        mock_client.api.user_stories.get_by_ref.return_value = {
+            "id": 50,
+            "ref": 42,
+            "milestone": 99,
+        }
+        mock_client.list_resources.return_value = [{"id": 77, "name": "Sprint 6", "closed": False}]
+        mock_client.api.tasks.create.return_value = {"id": 1, "ref": 1, "subject": "X"}
+        wf.create_task("p", 42, "X", sprint="Sprint 6", session_id=session)
+        data = mock_client.api.tasks.create.call_args.kwargs["data"]
+        assert data["milestone"] == 77
+
+
+class TestBreakDownStoryOverrides:
+    """Regression: loop path must honor all documented override keys."""
+
+    def _project(self):
+        return {"id": 1, "slug": "p", "name": "P"}
+
+    def test_loop_supports_tags_due_date_blocked(self, session, mock_client):
+        mock_client.api.get.return_value = self._project()
+        mock_client.api.user_stories.get_by_ref.return_value = {
+            "id": 50,
+            "ref": 42,
+            "milestone": None,
+        }
+        mock_client.api.tasks.create.return_value = {"id": 1, "ref": 1, "subject": "X"}
+        wf.break_down_story(
+            "p",
+            42,
+            [
+                {
+                    "subject": "X",
+                    "tags": ["a", "b"],
+                    "due_date": "2026-06-30",
+                    "blocked": True,
+                }
+            ],
+            session_id=session,
+        )
+        data = mock_client.api.tasks.create.call_args.kwargs["data"]
+        assert data["tags"] == ["a", "b"]
+        assert data["due_date"] == "2026-06-30"
+        assert data["is_blocked"] is True
+
+    def test_rejects_unknown_override_key(self, session, mock_client):
+        mock_client.api.get.return_value = self._project()
+        mock_client.api.user_stories.get_by_ref.return_value = {
+            "id": 50,
+            "ref": 42,
+            "milestone": None,
+        }
+        with pytest.raises(ValueError, match="Unknown per-task override keys"):
+            wf.break_down_story("p", 42, [{"subject": "X", "color": "red"}], session_id=session)
+        mock_client.api.tasks.create.assert_not_called()
+
+    def test_loop_path_inherits_parent_milestone(self, session, mock_client):
+        """Tasks created via loop path (overrides present) should still inherit milestone."""
+        mock_client.api.get.return_value = self._project()
+        mock_client.api.user_stories.get_by_ref.return_value = {
+            "id": 50,
+            "ref": 42,
+            "milestone": 99,
+        }
+        mock_client.api.tasks.create.return_value = {"id": 1, "ref": 1, "subject": "X"}
+        # Override forces loop path; milestone should still come through.
+        wf.break_down_story(
+            "p", 42, [{"subject": "X", "due_date": "2026-06-30"}], session_id=session
+        )
+        data = mock_client.api.tasks.create.call_args.kwargs["data"]
+        assert data["milestone"] == 99

--- a/tests/test_server_workflow.py
+++ b/tests/test_server_workflow.py
@@ -606,3 +606,232 @@ class TestUpdateStoryEpicRelink:
 
         with pytest.raises(ValueError, match="No fields to update"):
             wf.update_story("p", 5, session_id=session)
+
+
+# ---------------------------------------------------------------------------
+# Task tools (v2.1 — task/intent surface)
+# ---------------------------------------------------------------------------
+
+
+class TestCreateTask:
+    def _project(self):
+        return {"id": 1, "slug": "p", "name": "P"}
+
+    def test_creates_task_minimal(self, session, mock_client):
+        mock_client.api.get.return_value = self._project()
+        mock_client.api.user_stories.get_by_ref.return_value = {"id": 50, "ref": 42}
+        mock_client.api.tasks.create.return_value = {
+            "id": 200,
+            "ref": 7,
+            "subject": "Implement API",
+        }
+        result = wf.create_task("p", 42, "Implement API", session_id=session)
+        assert result["status"] == "created"
+        assert result["ref"] == 7
+        assert result["parent_story_ref"] == 42
+        call = mock_client.api.tasks.create.call_args
+        assert call.kwargs["project"] == 1
+        assert call.kwargs["subject"] == "Implement API"
+        assert call.kwargs["data"]["user_story"] == 50
+
+    def test_creates_task_with_assignee_and_status(self, session, mock_client):
+        mock_client.api.get.return_value = self._project()
+        mock_client.api.user_stories.get_by_ref.return_value = {"id": 50, "ref": 42}
+        # Two list_resources calls — one for task_statuses, one for memberships.
+        mock_client.list_resources.side_effect = [
+            [{"id": 11, "name": "In Progress"}],
+            [
+                {
+                    "user": 7,
+                    "full_name": "Alice",
+                    "email": "alice@example.com",
+                    "user_extra_info": {"username": "alice", "full_name_display": "Alice"},
+                }
+            ],
+        ]
+        mock_client.api.tasks.create.return_value = {"id": 200, "ref": 7, "subject": "API"}
+        wf.create_task("p", 42, "API", status="In Progress", assignee="alice", session_id=session)
+        data = mock_client.api.tasks.create.call_args.kwargs["data"]
+        assert data["status"] == 11
+        assert data["assigned_to"] == 7
+
+    def test_raises_when_parent_story_missing(self, session, mock_client):
+        mock_client.api.get.return_value = self._project()
+        mock_client.api.user_stories.get_by_ref.return_value = None
+        with pytest.raises(ValueError, match=r"User story #42 not found"):
+            wf.create_task("p", 42, "T", session_id=session)
+
+
+class TestUpdateTask:
+    def _project(self):
+        return {"id": 1, "slug": "p", "name": "P"}
+
+    def _task(self):
+        return {"id": 200, "ref": 7, "subject": "T", "version": 3, "user_story": 50}
+
+    def test_resolves_status_by_name(self, session, mock_client):
+        mock_client.api.get.return_value = self._project()
+        mock_client.api.tasks.get_by_ref.return_value = self._task()
+        mock_client.list_resources.return_value = [{"id": 12, "name": "Done"}]
+        mock_client.api.tasks.edit.return_value = {
+            "ref": 7,
+            "subject": "T",
+            "status_extra_info": {"name": "Done"},
+            "assigned_to_extra_info": None,
+            "is_blocked": False,
+        }
+        wf.update_task("p", 7, status="Done", session_id=session)
+        kwargs = mock_client.api.tasks.edit.call_args.kwargs
+        assert kwargs["status"] == 12
+        assert kwargs["version"] == 3
+
+    def test_reparent_resolves_story_ref(self, session, mock_client):
+        mock_client.api.get.return_value = self._project()
+        mock_client.api.tasks.get_by_ref.return_value = self._task()
+        # Subsequent get_by_ref call resolves the NEW parent story.
+        mock_client.api.user_stories.get_by_ref.return_value = {"id": 99, "ref": 44}
+        mock_client.api.tasks.edit.return_value = {
+            "ref": 7,
+            "subject": "T",
+            "status_extra_info": None,
+            "assigned_to_extra_info": None,
+            "is_blocked": False,
+        }
+        wf.update_task("p", 7, story_ref=44, session_id=session)
+        kwargs = mock_client.api.tasks.edit.call_args.kwargs
+        assert kwargs["user_story"] == 99
+
+    def test_sprint_move_supported(self, session, mock_client):
+        mock_client.api.get.return_value = self._project()
+        mock_client.api.tasks.get_by_ref.return_value = self._task()
+        mock_client.list_resources.return_value = [{"id": 33, "name": "Sprint 2", "closed": False}]
+        mock_client.api.tasks.edit.return_value = {
+            "ref": 7,
+            "subject": "T",
+            "status_extra_info": None,
+            "assigned_to_extra_info": None,
+            "is_blocked": False,
+        }
+        wf.update_task("p", 7, sprint="Sprint 2", session_id=session)
+        kwargs = mock_client.api.tasks.edit.call_args.kwargs
+        assert kwargs["milestone"] == 33
+
+    def test_no_op_raises(self, session, mock_client):
+        mock_client.api.get.return_value = self._project()
+        mock_client.api.tasks.get_by_ref.return_value = self._task()
+        with pytest.raises(ValueError, match="No fields to update"):
+            wf.update_task("p", 7, session_id=session)
+
+
+class TestSetTaskStatus:
+    def test_resolves_and_updates(self, session, mock_client):
+        mock_client.api.get.return_value = {"id": 1, "slug": "p", "name": "P"}
+        mock_client.list_resources.return_value = [{"id": 99, "name": "Done"}]
+        mock_client.api.tasks.get_by_ref.return_value = {"id": 200, "ref": 7, "version": 2}
+        mock_client.api.tasks.edit.return_value = {
+            "ref": 7,
+            "status_extra_info": {"name": "Done"},
+            "is_closed": True,
+        }
+        result = wf.set_task_status("p", 7, "Done", session_id=session)
+        assert result["status"] == "Done"
+        assert result["is_closed"] is True
+        # Confirm uses task_statuses, not userstory_statuses.
+        mock_client.list_resources.assert_called_once_with("task_statuses", project_id=1)
+
+
+class TestBreakDownStory:
+    def _project(self):
+        return {"id": 1, "slug": "p", "name": "P"}
+
+    def test_empty_list_raises(self, session, mock_client):
+        with pytest.raises(ValueError, match="tasks list cannot be empty"):
+            wf.break_down_story("p", 42, [], session_id=session)
+
+    def test_bulk_path_when_story_in_sprint(self, session, mock_client):
+        """No overrides + story has milestone → bulk_create endpoint, one call."""
+        mock_client.api.get.return_value = self._project()
+        mock_client.api.user_stories.get_by_ref.return_value = {
+            "id": 50,
+            "ref": 42,
+            "milestone": 33,
+        }
+        mock_client.api.post.return_value = [
+            {"ref": 10, "subject": "design"},
+            {"ref": 11, "subject": "API"},
+            {"ref": 12, "subject": "tests"},
+        ]
+        result = wf.break_down_story("p", 42, ["design", "API", "tests"], session_id=session)
+        assert result["status"] == "decomposed"
+        assert result["tasks_created"] == 3
+        # Single bulk POST, zero individual tasks.create calls.
+        mock_client.api.post.assert_called_once()
+        args, kwargs = mock_client.api.post.call_args.args, mock_client.api.post.call_args.kwargs
+        assert args[0] == "/tasks/bulk_create"
+        assert kwargs["json"]["us_id"] == 50
+        assert kwargs["json"]["milestone_id"] == 33
+        assert kwargs["json"]["bulk_tasks"] == "design\nAPI\ntests"
+        mock_client.api.tasks.create.assert_not_called()
+
+    def test_loop_path_when_story_in_backlog(self, session, mock_client):
+        """No milestone on story → fall back to individual creates."""
+        mock_client.api.get.return_value = self._project()
+        mock_client.api.user_stories.get_by_ref.return_value = {
+            "id": 50,
+            "ref": 42,
+            "milestone": None,
+        }
+        mock_client.api.tasks.create.side_effect = [
+            {"ref": 10, "subject": "design"},
+            {"ref": 11, "subject": "API"},
+        ]
+        result = wf.break_down_story("p", 42, ["design", "API"], session_id=session)
+        assert result["tasks_created"] == 2
+        # No bulk endpoint, one create per task.
+        mock_client.api.post.assert_not_called()
+        assert mock_client.api.tasks.create.call_count == 2
+
+    def test_loop_path_when_per_task_overrides(self, session, mock_client):
+        """Per-task overrides force the loop path even with a milestone."""
+        mock_client.api.get.return_value = self._project()
+        mock_client.api.user_stories.get_by_ref.return_value = {
+            "id": 50,
+            "ref": 42,
+            "milestone": 33,
+        }
+        mock_client.list_resources.return_value = [
+            {
+                "user": 7,
+                "full_name": "Alice",
+                "email": "a@x",
+                "user_extra_info": {"username": "alice", "full_name_display": "Alice"},
+            }
+        ]
+        mock_client.api.tasks.create.side_effect = [
+            {"ref": 10, "subject": "design"},
+            {"ref": 11, "subject": "API"},
+        ]
+        result = wf.break_down_story(
+            "p",
+            42,
+            [
+                {"subject": "design"},
+                {"subject": "API", "assignee": "alice"},
+            ],
+            session_id=session,
+        )
+        assert result["tasks_created"] == 2
+        # Per-task override forced the loop, not the bulk endpoint.
+        mock_client.api.post.assert_not_called()
+        # Second call assigned to Alice.
+        assert mock_client.api.tasks.create.call_args_list[1].kwargs["data"]["assigned_to"] == 7
+
+    def test_rejects_malformed_entries(self, session, mock_client):
+        mock_client.api.get.return_value = self._project()
+        mock_client.api.user_stories.get_by_ref.return_value = {
+            "id": 50,
+            "ref": 42,
+            "milestone": None,
+        }
+        with pytest.raises(ValueError, match="must be a non-empty string or a dict"):
+            wf.break_down_story("p", 42, [{"no_subject": "oops"}], session_id=session)

--- a/uv.lock
+++ b/uv.lock
@@ -712,7 +712,7 @@ cli = [
 
 [[package]]
 name = "mcp-taiga-bridge"
-version = "2.0.0"
+version = "1.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },


### PR DESCRIPTION
## Summary

Closes the task-management gap in workflow mode. Before this PR, `assign_item(entity_type=\"task\", …)` and `add_comment(entity_type=\"task\", …)` worked for tasks, but there was no way to *create* or *update* tasks without dropping to full mode. A PO breaking down a sprint story had to switch modes — counter to the workflow-surface promise.

Adds 4 new intent-based tools (workflow surface goes 23 → 27):

| Tool | Intent |
|---|---|
| `create_task(project, story_ref, subject, …)` | Add a single task under an existing story |
| `update_task(project, ref, …)` | Name-resolved field updates incl. sprint move + story reparent |
| `set_task_status(project, ref, status)` | Quick status flip — mirrors `set_story_status` |
| `break_down_story(project, story_ref, tasks=[…])` | Decompose a story into multiple tasks in one call |

### `break_down_story` — bulk-aware

Accepts either subject strings (`['design', 'API', 'tests']`) or dicts (`[{'subject': 'design'}, {'subject': 'API', 'assignee': 'alice'}]`).

- **Bulk path**: when the parent story is in a sprint AND no per-task overrides → uses Taiga's `/tasks/bulk_create` endpoint, one API call for N tasks.
- **Loop path**: when the story is in the backlog (no milestone) OR per-task overrides are present → falls back to per-task `tasks.create` calls. Both cases that the bulk endpoint can't handle (it's sprint-scoped and accepts only a flat subject list).

The LLM doesn't need to know about this distinction — the tool picks the right path automatically.

### Design notes

- Reuses existing helpers: `_resolve_status` already supports `entity_type=\"task\"`; `_resolve_user`, `_resolve_sprint`, `_resolve_project` work as-is.
- Tasks in Taiga can have a milestone independent of their parent story — `update_task(sprint=…)` honors that (explicit move per user decision).
- `update_task(story_ref=N)` reparents the task to a different user story — rare but real workflow.

## Test plan

- [x] 17 new unit tests in `tests/test_server_workflow.py`:
  - 3 for `create_task` (minimal, with assignee+status, parent-missing error)
  - 4 for `update_task` (status by name, reparent, sprint move, no-op raises)
  - 1 for `set_task_status` (uses `task_statuses` resource, not `userstory_statuses`)
  - 5 for `break_down_story` (empty, bulk path, loop path on backlog, loop path on overrides, malformed entries)
- [x] Full suite: **383 passing** (was 366), ruff clean, pre-commit green
- [ ] Smoke test against `taiga.tetra-ai.fr` post-merge with a real sprint