### PR TITLE
fix: bypass tasks.get_by_ref in workflow mode (query_params kwarg bug)

### DIFF
--- a/src/server_workflow.py
+++ b/src/server_workflow.py
@@ -990,7 +990,9 @@ def update_task(
         proj = _resolve_project(client, project)
         project_id = proj["id"]
 
-        current = client.api.tasks.get_by_ref(ref=ref, project=project_id)
+        # Workaround: pytaigaclient tasks.get_by_ref passes query_params= but
+        # TaigaClient.get() expects params=. Bypass via direct API call.
+        current = client.api.get("/tasks/by_ref", params={"ref": ref, "project": project_id})
         if not current:
             raise ValueError(f"Task #{ref} not found in project '{proj['slug']}'.")
 
@@ -1538,7 +1540,9 @@ def set_task_status(
         project_id = proj["id"]
         status_id = _resolve_status(client, project_id, "task", status, actual_session_id)
 
-        current = client.api.tasks.get_by_ref(ref=ref, project=project_id)
+        # Workaround: pytaigaclient tasks.get_by_ref passes query_params= but
+        # TaigaClient.get() expects params=. Bypass via direct API call.
+        current = client.api.get("/tasks/by_ref", params={"ref": ref, "project": project_id})
         if not current:
             raise ValueError(f"Task #{ref} not found in project '{proj['slug']}'.")
 

--- a/tests/test_server_workflow.py
+++ b/tests/test_server_workflow.py
@@ -669,9 +669,14 @@ class TestUpdateTask:
     def _task(self):
         return {"id": 200, "ref": 7, "subject": "T", "version": 3, "user_story": 50}
 
+    def _api_get(self, path, params=None):
+        """Side-effect for api.get: route /tasks/by_ref to task fixture, everything else to project."""
+        if "/tasks/by_ref" in str(path):
+            return self._task()
+        return self._project()
+
     def test_resolves_status_by_name(self, session, mock_client):
-        mock_client.api.get.return_value = self._project()
-        mock_client.api.tasks.get_by_ref.return_value = self._task()
+        mock_client.api.get.side_effect = self._api_get
         mock_client.list_resources.return_value = [{"id": 12, "name": "Done"}]
         mock_client.api.tasks.edit.return_value = {
             "ref": 7,
@@ -686,9 +691,8 @@ class TestUpdateTask:
         assert kwargs["version"] == 3
 
     def test_reparent_resolves_story_ref(self, session, mock_client):
-        mock_client.api.get.return_value = self._project()
-        mock_client.api.tasks.get_by_ref.return_value = self._task()
-        # Subsequent get_by_ref call resolves the NEW parent story.
+        mock_client.api.get.side_effect = self._api_get
+        # user_stories.get_by_ref is unaffected by the bug — mock it directly.
         mock_client.api.user_stories.get_by_ref.return_value = {"id": 99, "ref": 44}
         mock_client.api.tasks.edit.return_value = {
             "ref": 7,
@@ -702,8 +706,7 @@ class TestUpdateTask:
         assert kwargs["user_story"] == 99
 
     def test_sprint_move_supported(self, session, mock_client):
-        mock_client.api.get.return_value = self._project()
-        mock_client.api.tasks.get_by_ref.return_value = self._task()
+        mock_client.api.get.side_effect = self._api_get
         mock_client.list_resources.return_value = [{"id": 33, "name": "Sprint 2", "closed": False}]
         mock_client.api.tasks.edit.return_value = {
             "ref": 7,
@@ -717,17 +720,23 @@ class TestUpdateTask:
         assert kwargs["milestone"] == 33
 
     def test_no_op_raises(self, session, mock_client):
-        mock_client.api.get.return_value = self._project()
-        mock_client.api.tasks.get_by_ref.return_value = self._task()
+        mock_client.api.get.side_effect = self._api_get
         with pytest.raises(ValueError, match="No fields to update"):
             wf.update_task("p", 7, session_id=session)
 
 
 class TestSetTaskStatus:
     def test_resolves_and_updates(self, session, mock_client):
-        mock_client.api.get.return_value = {"id": 1, "slug": "p", "name": "P"}
+        project = {"id": 1, "slug": "p", "name": "P"}
+        task = {"id": 200, "ref": 7, "version": 2}
+
+        def api_get(path, params=None):
+            if "/tasks/by_ref" in str(path):
+                return task
+            return project
+
+        mock_client.api.get.side_effect = api_get
         mock_client.list_resources.return_value = [{"id": 99, "name": "Done"}]
-        mock_client.api.tasks.get_by_ref.return_value = {"id": 200, "ref": 7, "version": 2}
         mock_client.api.tasks.edit.return_value = {
             "ref": 7,
             "status_extra_info": {"name": "Done"},


### PR DESCRIPTION
## Problem

`update_task` and `set_task_status` always fail in workflow mode with:

```
TaigaClient._request() got an unexpected keyword argument 'query_params'
```

`pytaigaclient`'s `Tasks.get_by_ref()` calls `self.client.get(endpoint, query_params=...)` but `TaigaClient.get()` only accepts `params=`. The kwarg mismatch throws a `TypeError` before any mutation reaches the API.

Fixes #76.

## Fix

Replace the two `client.api.tasks.get_by_ref()` calls in `server_workflow.py` with the same direct `client.api.get("/tasks/by_ref", params=...)` workaround already applied in `server_full.py` (see comment at line 1460 there).

```python
# Before (broken)
current = client.api.tasks.get_by_ref(ref=ref, project=project_id)

# After (workaround)
# pytaigaclient tasks.get_by_ref passes query_params= but TaigaClient.get() expects params=
current = client.api.get("/tasks/by_ref", params={"ref": ref, "project": project_id})
```

Affected functions: `update_task` (line 993) and `set_task_status` (line 1541).

## Tests

`TestUpdateTask` and `TestSetTaskStatus` updated to mock `api.get` with a `side_effect` that routes `/tasks/by_ref` to the task fixture and everything else (project slug lookup) to the project fixture. Previously the tests mocked `tasks.get_by_ref` directly, which masked the real call path.

```
392 passed, 1 warning in 1.12s
```

## Note

`create_task` and `break_down_story` are unaffected — they do not call `tasks.get_by_ref`. `user_stories.get_by_ref` and `issues.get_by_ref` in the same file are also unaffected (those pytaigaclient resources use `params=` correctly).