### PR TITLE
fix: bypass Tasks/Issues fixed-signature edit() and tasks.get_by_ref query_params bug

### DIFF
--- a/src/server_workflow.py
+++ b/src/server_workflow.py
@@ -1023,7 +1023,7 @@ def update_task(
         if len(payload) == 1:  # only version key
             raise ValueError("No fields to update were provided.")
 
-        result = client.api.tasks.edit(current["id"], **payload)
+        result = client.api.patch(f"/tasks/{current['id']}", json=payload)
         return _task_summary(result)
 
     return _execute_taiga_operation("update_task", do_update, f"task #{ref} in {project}")
@@ -1285,7 +1285,7 @@ def update_issue(
         if len(payload) == 1:
             raise ValueError("No fields to update were provided.")
 
-        result = client.api.issues.edit(current["id"], **payload)
+        result = client.api.patch(f"/issues/{current['id']}", json=payload)
         return {
             "ref": result.get("ref"),
             "subject": result.get("subject"),
@@ -1546,7 +1546,9 @@ def set_task_status(
         if not current:
             raise ValueError(f"Task #{ref} not found in project '{proj['slug']}'.")
 
-        result = client.api.tasks.edit(current["id"], status=status_id, version=current["version"])
+        result = client.api.patch(
+            f"/tasks/{current['id']}", json={"status": status_id, "version": current["version"]}
+        )
         return {
             "ref": ref,
             "status": (result.get("status_extra_info") or {}).get("name") or status,
@@ -1799,13 +1801,17 @@ def assign_item(
         project_id = proj["id"]
         user_id = _resolve_user(client, project_id, username, actual_session_id)
 
-        collection_name, _ = type_map[entity_type]
-        collection = getattr(client.api, collection_name)
-        current = collection.get_by_ref(ref=ref, project=project_id)
+        # Direct GET/PATCH avoids pytaigaclient query_params= bug (tasks) and
+        # fixed-signature edit() that rejects **kwargs (tasks, issues).
+        api_path = _COMMENT_PATH_MAP[entity_type]
+        current = client.api.get(f"/{api_path}/by_ref", params={"ref": ref, "project": project_id})
         if not current:
             raise ValueError(f"{entity_type.capitalize()} #{ref} not found in '{proj['slug']}'.")
 
-        result = collection.edit(current["id"], assigned_to=user_id, version=current["version"])
+        result = client.api.patch(
+            f"/{api_path}/{current['id']}",
+            json={"assigned_to": user_id, "version": current["version"]},
+        )
         return {
             "ref": ref,
             "entity_type": entity_type,
@@ -1921,16 +1927,10 @@ def add_comment(
         project_id = proj["id"]
         path_segment = _COMMENT_PATH_MAP[entity_type]
 
-        # Resolve ref → ID
-        collection_name = {
-            "story": "user_stories",
-            "user_story": "user_stories",
-            "task": "tasks",
-            "issue": "issues",
-            "epic": "epics",
-        }[entity_type]
-        collection = getattr(client.api, collection_name)
-        current = collection.get_by_ref(ref=ref, project=project_id)
+        # Resolve ref → ID via direct GET (avoids pytaigaclient query_params= bug on tasks)
+        current = client.api.get(
+            f"/{path_segment}/by_ref", params={"ref": ref, "project": project_id}
+        )
         if not current:
             raise ValueError(f"{entity_type.capitalize()} #{ref} not found in '{proj['slug']}'.")
 

--- a/tests/test_server_workflow.py
+++ b/tests/test_server_workflow.py
@@ -1029,11 +1029,6 @@ class TestUpdateIssue:
     def _issue(self):
         return {"id": 300, "ref": 12, "version": 4}
 
-    def _api_get(self, path, params=None):
-        if "/issues/by_ref" in str(path):
-            return self._issue()
-        return self._project()
-
     def test_subject_and_description_patched_directly(self, session, mock_client):
         """update_issue must bypass issues.edit() (fixed-signature) via direct PATCH."""
         mock_client.api.issues.get_by_ref.return_value = self._issue()

--- a/tests/test_server_workflow.py
+++ b/tests/test_server_workflow.py
@@ -678,7 +678,7 @@ class TestUpdateTask:
     def test_resolves_status_by_name(self, session, mock_client):
         mock_client.api.get.side_effect = self._api_get
         mock_client.list_resources.return_value = [{"id": 12, "name": "Done"}]
-        mock_client.api.tasks.edit.return_value = {
+        mock_client.api.patch.return_value = {
             "ref": 7,
             "subject": "T",
             "status_extra_info": {"name": "Done"},
@@ -686,15 +686,15 @@ class TestUpdateTask:
             "is_blocked": False,
         }
         wf.update_task("p", 7, status="Done", session_id=session)
-        kwargs = mock_client.api.tasks.edit.call_args.kwargs
-        assert kwargs["status"] == 12
-        assert kwargs["version"] == 3
+        payload = mock_client.api.patch.call_args.kwargs["json"]
+        assert payload["status"] == 12
+        assert payload["version"] == 3
 
     def test_reparent_resolves_story_ref(self, session, mock_client):
         mock_client.api.get.side_effect = self._api_get
         # user_stories.get_by_ref is unaffected by the bug — mock it directly.
         mock_client.api.user_stories.get_by_ref.return_value = {"id": 99, "ref": 44}
-        mock_client.api.tasks.edit.return_value = {
+        mock_client.api.patch.return_value = {
             "ref": 7,
             "subject": "T",
             "status_extra_info": None,
@@ -702,13 +702,13 @@ class TestUpdateTask:
             "is_blocked": False,
         }
         wf.update_task("p", 7, story_ref=44, session_id=session)
-        kwargs = mock_client.api.tasks.edit.call_args.kwargs
-        assert kwargs["user_story"] == 99
+        payload = mock_client.api.patch.call_args.kwargs["json"]
+        assert payload["user_story"] == 99
 
     def test_sprint_move_supported(self, session, mock_client):
         mock_client.api.get.side_effect = self._api_get
         mock_client.list_resources.return_value = [{"id": 33, "name": "Sprint 2", "closed": False}]
-        mock_client.api.tasks.edit.return_value = {
+        mock_client.api.patch.return_value = {
             "ref": 7,
             "subject": "T",
             "status_extra_info": None,
@@ -716,8 +716,8 @@ class TestUpdateTask:
             "is_blocked": False,
         }
         wf.update_task("p", 7, sprint="Sprint 2", session_id=session)
-        kwargs = mock_client.api.tasks.edit.call_args.kwargs
-        assert kwargs["milestone"] == 33
+        payload = mock_client.api.patch.call_args.kwargs["json"]
+        assert payload["milestone"] == 33
 
     def test_no_op_raises(self, session, mock_client):
         mock_client.api.get.side_effect = self._api_get
@@ -737,7 +737,7 @@ class TestSetTaskStatus:
 
         mock_client.api.get.side_effect = api_get
         mock_client.list_resources.return_value = [{"id": 99, "name": "Done"}]
-        mock_client.api.tasks.edit.return_value = {
+        mock_client.api.patch.return_value = {
             "ref": 7,
             "status_extra_info": {"name": "Done"},
             "is_closed": True,

--- a/tests/test_server_workflow.py
+++ b/tests/test_server_workflow.py
@@ -747,6 +747,10 @@ class TestSetTaskStatus:
         assert result["is_closed"] is True
         # Confirm uses task_statuses, not userstory_statuses.
         mock_client.list_resources.assert_called_once_with("task_statuses", project_id=1)
+        # Confirm PATCH payload carries resolved status ID and version.
+        patch_payload = mock_client.api.patch.call_args.kwargs["json"]
+        assert patch_payload["status"] == 99
+        assert patch_payload["version"] == 2
 
 
 class TestBreakDownStory:
@@ -1016,3 +1020,138 @@ class TestBreakDownStoryBulkShapeWarn:
         assert any(
             "Unexpected /tasks/bulk_create response shape" in rec.message for rec in caplog.records
         )
+
+
+class TestUpdateIssue:
+    def _project(self):
+        return {"id": 1, "slug": "p", "name": "P"}
+
+    def _issue(self):
+        return {"id": 300, "ref": 12, "version": 4}
+
+    def _api_get(self, path, params=None):
+        if "/issues/by_ref" in str(path):
+            return self._issue()
+        return self._project()
+
+    def test_subject_and_description_patched_directly(self, session, mock_client):
+        """update_issue must bypass issues.edit() (fixed-signature) via direct PATCH."""
+        mock_client.api.issues.get_by_ref.return_value = self._issue()
+        mock_client.api.get.return_value = self._project()
+        mock_client.api.patch.return_value = {
+            "ref": 12,
+            "subject": "New subject",
+            "status_extra_info": None,
+            "priority_extra_info": None,
+            "severity_extra_info": None,
+            "type_extra_info": None,
+            "assigned_to_extra_info": None,
+            "is_blocked": False,
+        }
+        wf.update_issue("p", 12, subject="New subject", description="desc", session_id=session)
+        payload = mock_client.api.patch.call_args.kwargs["json"]
+        assert payload["subject"] == "New subject"
+        assert payload["description"] == "desc"
+        assert payload["version"] == 4
+
+    def test_no_op_raises(self, session, mock_client):
+        mock_client.api.issues.get_by_ref.return_value = self._issue()
+        mock_client.api.get.return_value = self._project()
+        with pytest.raises(ValueError, match="No fields to update"):
+            wf.update_issue("p", 12, session_id=session)
+
+
+class TestAddComment:
+    def _project(self):
+        return {"id": 1, "slug": "p", "name": "P"}
+
+    def test_task_comment_uses_direct_get(self, session, mock_client):
+        """add_comment for entity_type=task must use direct GET (not tasks.get_by_ref)."""
+        task = {"id": 200, "ref": 7, "version": 3}
+
+        def api_get(path, params=None):
+            if "/tasks/by_ref" in str(path):
+                return task
+            return self._project()
+
+        mock_client.api.get.side_effect = api_get
+        wf.add_comment("p", 7, "hello task", entity_type="task", session_id=session)
+
+        # Verify by_ref was fetched via client.api.get, not tasks.get_by_ref
+        get_calls = [str(c.args[0]) for c in mock_client.api.get.call_args_list]
+        assert any("/tasks/by_ref" in p for p in get_calls)
+        mock_client.api.tasks.get_by_ref.assert_not_called()
+
+        # Verify comment was PATCHed to the correct task endpoint
+        patch_call = mock_client.api.patch.call_args
+        assert "/tasks/200" in patch_call.args[0]
+        assert patch_call.kwargs["json"]["comment"] == "hello task"
+        assert patch_call.kwargs["json"]["version"] == 3
+
+    def test_story_comment_still_works(self, session, mock_client):
+        """add_comment for entity_type=story continues to use the same direct GET path."""
+        story = {"id": 50, "ref": 5, "version": 1}
+
+        def api_get(path, params=None):
+            if "/userstories/by_ref" in str(path):
+                return story
+            return self._project()
+
+        mock_client.api.get.side_effect = api_get
+        wf.add_comment("p", 5, "hello story", entity_type="story", session_id=session)
+
+        patch_call = mock_client.api.patch.call_args
+        assert "/userstories/50" in patch_call.args[0]
+        assert patch_call.kwargs["json"]["comment"] == "hello story"
+
+
+class TestAssignItem:
+    def _project(self):
+        return {"id": 1, "slug": "p", "name": "P"}
+
+    def _api_get(self, entity_path):
+        def side_effect(path, params=None):
+            if entity_path in str(path) and "by_ref" in str(path):
+                return {"id": 200, "ref": 7, "version": 2}
+            return self._project()
+
+        return side_effect
+
+    def _mock_members(self, mock_client):
+        mock_client.list_resources.return_value = [
+            {"user": 42, "user_extra_info": {"username": "alice", "full_name_display": "Alice"}}
+        ]
+
+    def test_assign_task_uses_direct_get_and_patch(self, session, mock_client):
+        """assign_item for entity_type=task must bypass tasks.get_by_ref and tasks.edit."""
+        mock_client.api.get.side_effect = self._api_get("tasks")
+        self._mock_members(mock_client)
+        mock_client.api.patch.return_value = {
+            "assigned_to_extra_info": {"full_name_display": "Alice"}
+        }
+        result = wf.assign_item("p", 7, "alice", entity_type="task", session_id=session)
+
+        mock_client.api.tasks.get_by_ref.assert_not_called()
+        mock_client.api.tasks.edit.assert_not_called()
+
+        patch_call = mock_client.api.patch.call_args
+        assert "/tasks/200" in patch_call.args[0]
+        assert patch_call.kwargs["json"]["assigned_to"] == 42
+        assert patch_call.kwargs["json"]["version"] == 2
+        assert result["assigned_to"] == "Alice"
+
+    def test_assign_issue_uses_direct_patch(self, session, mock_client):
+        """assign_item for entity_type=issue must bypass issues.edit (fixed-signature)."""
+        mock_client.api.get.side_effect = self._api_get("issues")
+        self._mock_members(mock_client)
+        mock_client.api.patch.return_value = {
+            "assigned_to_extra_info": {"full_name_display": "Alice"}
+        }
+        result = wf.assign_item("p", 7, "alice", entity_type="issue", session_id=session)
+
+        mock_client.api.issues.edit.assert_not_called()
+
+        patch_call = mock_client.api.patch.call_args
+        assert "/issues/200" in patch_call.args[0]
+        assert patch_call.kwargs["json"]["assigned_to"] == 42
+        assert result["assigned_to"] == "Alice"


### PR DESCRIPTION
Closes #79

## Root causes

Two distinct pytaigaclient bugs affect task and issue tools:

**Bug A — Fixed-signature `edit()` rejects keyword args** (`tasks.edit`, `issues.edit`)

`Tasks.edit(task_id, version, data)` and `Issues.edit(issue_id, version, data)` take a positional `data: Dict` — not `**kwargs`. Calling them as `tasks.edit(id, **payload)` or `tasks.edit(id, status=x, version=y)` raises `TypeError: unexpected keyword argument`. By contrast, `UserStories.edit` and `Epics.edit` use `**kwargs` and work fine.

**Bug B — `tasks.get_by_ref` passes `query_params=` instead of `params=`**

`TaigaClient.get()` expects `params=`; `tasks.get_by_ref` passes `query_params=` → silent failure. This was already worked around in `update_task` and `set_task_status` but was missing in `add_comment` and `assign_item`.

## Affected tools (pre-fix)

| Tool | Bug A | Bug B |
|---|---|---|
| `update_task` | ✅ (all fields except status-only) | already fixed |
| `set_task_status` | ✅ (status= kwarg rejected) | already fixed |
| `update_issue` | ✅ (subject/description) | n/a |
| `add_comment` entity_type=task | — | ✅ |
| `assign_item` entity_type=task | ✅ | ✅ |
| `assign_item` entity_type=issue | ✅ | n/a |

## Fix

Replace all broken call sites with `client.api.patch(path, json=payload)` (already proven for wiki/comments) and replace `collection.get_by_ref` with `client.api.get(f"/{path}/by_ref", params=...)` using `_COMMENT_PATH_MAP` for the path segment — consistent with the existing workarounds.

## Tests

4 existing unit tests updated to assert on `api.patch` call args. All 381 tests pass, ruff clean.