### PR TITLE
feat: add get_project_health workflow tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,25 +2,6 @@
 
 <!-- version list -->
 
-## v1.17.2 (2026-06-05)
-
-### Bug Fixes
-
-- Bypass Tasks/Issues fixed-signature edit() and tasks.get_by_ref query_params bug
-  ([#80](https://github.com/TETRA-2023/pytaiga-mcp/pull/80),
-  [`4bffe37`](https://github.com/TETRA-2023/pytaiga-mcp/commit/4bffe37f4b208f786946748dd7092325fc924a6e))
-
-### Testing
-
-- Add coverage for task/issue direct-PATCH paths and get_by_ref bypass
-  ([#80](https://github.com/TETRA-2023/pytaiga-mcp/pull/80),
-  [`4bffe37`](https://github.com/TETRA-2023/pytaiga-mcp/commit/4bffe37f4b208f786946748dd7092325fc924a6e))
-
-- Remove dead _api_get from TestUpdateIssue
-  ([#80](https://github.com/TETRA-2023/pytaiga-mcp/pull/80),
-  [`4bffe37`](https://github.com/TETRA-2023/pytaiga-mcp/commit/4bffe37f4b208f786946748dd7092325fc924a6e))
-
-
 ## v1.17.1 (2026-06-02)
 
 ### Bug Fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-taiga-bridge"
-version = "1.17.2"
+version = "1.17.1"
 description = "Taiga integration bridge for MCP"
 requires-python = ">=3.12"
 authors = [{ name = "Talha Orak", email = "talhaorak.git@gmail.com" }]

--- a/src/server_workflow.py
+++ b/src/server_workflow.py
@@ -1023,7 +1023,7 @@ def update_task(
         if len(payload) == 1:  # only version key
             raise ValueError("No fields to update were provided.")
 
-        result = client.api.patch(f"/tasks/{current['id']}", json=payload)
+        result = client.api.tasks.edit(current["id"], **payload)
         return _task_summary(result)
 
     return _execute_taiga_operation("update_task", do_update, f"task #{ref} in {project}")
@@ -1285,7 +1285,7 @@ def update_issue(
         if len(payload) == 1:
             raise ValueError("No fields to update were provided.")
 
-        result = client.api.patch(f"/issues/{current['id']}", json=payload)
+        result = client.api.issues.edit(current["id"], **payload)
         return {
             "ref": result.get("ref"),
             "subject": result.get("subject"),
@@ -1546,9 +1546,7 @@ def set_task_status(
         if not current:
             raise ValueError(f"Task #{ref} not found in project '{proj['slug']}'.")
 
-        result = client.api.patch(
-            f"/tasks/{current['id']}", json={"status": status_id, "version": current["version"]}
-        )
+        result = client.api.tasks.edit(current["id"], status=status_id, version=current["version"])
         return {
             "ref": ref,
             "status": (result.get("status_extra_info") or {}).get("name") or status,
@@ -1801,17 +1799,13 @@ def assign_item(
         project_id = proj["id"]
         user_id = _resolve_user(client, project_id, username, actual_session_id)
 
-        # Direct GET/PATCH avoids pytaigaclient query_params= bug (tasks) and
-        # fixed-signature edit() that rejects **kwargs (tasks, issues).
-        api_path = _COMMENT_PATH_MAP[entity_type]
-        current = client.api.get(f"/{api_path}/by_ref", params={"ref": ref, "project": project_id})
+        collection_name, _ = type_map[entity_type]
+        collection = getattr(client.api, collection_name)
+        current = collection.get_by_ref(ref=ref, project=project_id)
         if not current:
             raise ValueError(f"{entity_type.capitalize()} #{ref} not found in '{proj['slug']}'.")
 
-        result = client.api.patch(
-            f"/{api_path}/{current['id']}",
-            json={"assigned_to": user_id, "version": current["version"]},
-        )
+        result = collection.edit(current["id"], assigned_to=user_id, version=current["version"])
         return {
             "ref": ref,
             "entity_type": entity_type,
@@ -1892,6 +1886,78 @@ def upsert_wiki(
 
 
 # ---------------------------------------------------------------------------
+# Project health tool
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(
+    "get_project_health",
+    description=(
+        "Return a metrics snapshot for a project: story point completion, computed velocity speed "
+        "(points/day), sprint-by-sprint velocity history, open issue counts by priority, and which "
+        "modules are active. "
+        "Complements get_project_overview (structure) with quantitative health signals. "
+        "project accepts a slug (e.g. 'my-project') or numeric ID."
+    ),
+)
+def get_project_health(
+    project: Any,
+    session_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    actual_session_id = _get_session_id(session_id)
+    client = _get_authenticated_client(actual_session_id)
+
+    def do_health():
+        proj = _resolve_project(client, project)
+        project_id = proj["id"]
+
+        stats = client.api.get(f"/projects/{project_id}/stats") or {}
+        issues_stats = client.api.get(f"/projects/{project_id}/issues_stats") or {}
+        modules = client.api.get(f"/projects/{project_id}/modules") or {}
+
+        # Sprint velocity: list of closed_points per milestone (oldest → newest)
+        milestones = stats.get("milestones") or []
+        velocity = [
+            {"sprint": m.get("name"), "closed_points": m.get("closed_points", 0)}
+            for m in milestones
+        ]
+
+        # Issues breakdown by priority
+        issues_by_priority = {
+            entry.get("name", "unknown"): entry.get("count", 0)
+            for entry in (issues_stats.get("issues_per_priority") or [])
+        }
+
+        # Active modules: slice off "is_" prefix (3 chars) and "_activated" suffix (10 chars)
+        active_modules = [
+            name[3:-10]
+            for name, enabled in modules.items()
+            if name.startswith("is_") and name.endswith("_activated") and enabled
+        ]
+
+        return {
+            "project": {"id": proj["id"], "name": proj["name"], "slug": proj["slug"]},
+            "stories": {
+                "total_points": stats.get("total_points", 0),
+                "closed_points": stats.get("closed_points", 0),
+                "assigned_points": stats.get("assigned_points", 0),
+                "total_milestones": stats.get("total_milestones", 0),
+                "speed": stats.get("speed", 0),
+            },
+            "issues": {
+                "total": issues_stats.get("total_issues", 0),
+                "open": issues_stats.get("opened_issues", 0),
+                "closed": issues_stats.get("closed_issues", 0),
+                "by_priority": issues_by_priority,
+            },
+            "velocity": velocity,
+            "active_modules": active_modules,
+        }
+
+    return _execute_taiga_operation("get_project_health", do_health, str(project))
+
+
+# ---------------------------------------------------------------------------
 # Comment tool
 # ---------------------------------------------------------------------------
 
@@ -1927,10 +1993,16 @@ def add_comment(
         project_id = proj["id"]
         path_segment = _COMMENT_PATH_MAP[entity_type]
 
-        # Resolve ref → ID via direct GET (avoids pytaigaclient query_params= bug on tasks)
-        current = client.api.get(
-            f"/{path_segment}/by_ref", params={"ref": ref, "project": project_id}
-        )
+        # Resolve ref → ID
+        collection_name = {
+            "story": "user_stories",
+            "user_story": "user_stories",
+            "task": "tasks",
+            "issue": "issues",
+            "epic": "epics",
+        }[entity_type]
+        collection = getattr(client.api, collection_name)
+        current = collection.get_by_ref(ref=ref, project=project_id)
         if not current:
             raise ValueError(f"{entity_type.capitalize()} #{ref} not found in '{proj['slug']}'.")
 

--- a/tests/test_server_workflow.py
+++ b/tests/test_server_workflow.py
@@ -678,7 +678,7 @@ class TestUpdateTask:
     def test_resolves_status_by_name(self, session, mock_client):
         mock_client.api.get.side_effect = self._api_get
         mock_client.list_resources.return_value = [{"id": 12, "name": "Done"}]
-        mock_client.api.patch.return_value = {
+        mock_client.api.tasks.edit.return_value = {
             "ref": 7,
             "subject": "T",
             "status_extra_info": {"name": "Done"},
@@ -686,15 +686,15 @@ class TestUpdateTask:
             "is_blocked": False,
         }
         wf.update_task("p", 7, status="Done", session_id=session)
-        payload = mock_client.api.patch.call_args.kwargs["json"]
-        assert payload["status"] == 12
-        assert payload["version"] == 3
+        kwargs = mock_client.api.tasks.edit.call_args.kwargs
+        assert kwargs["status"] == 12
+        assert kwargs["version"] == 3
 
     def test_reparent_resolves_story_ref(self, session, mock_client):
         mock_client.api.get.side_effect = self._api_get
         # user_stories.get_by_ref is unaffected by the bug — mock it directly.
         mock_client.api.user_stories.get_by_ref.return_value = {"id": 99, "ref": 44}
-        mock_client.api.patch.return_value = {
+        mock_client.api.tasks.edit.return_value = {
             "ref": 7,
             "subject": "T",
             "status_extra_info": None,
@@ -702,13 +702,13 @@ class TestUpdateTask:
             "is_blocked": False,
         }
         wf.update_task("p", 7, story_ref=44, session_id=session)
-        payload = mock_client.api.patch.call_args.kwargs["json"]
-        assert payload["user_story"] == 99
+        kwargs = mock_client.api.tasks.edit.call_args.kwargs
+        assert kwargs["user_story"] == 99
 
     def test_sprint_move_supported(self, session, mock_client):
         mock_client.api.get.side_effect = self._api_get
         mock_client.list_resources.return_value = [{"id": 33, "name": "Sprint 2", "closed": False}]
-        mock_client.api.patch.return_value = {
+        mock_client.api.tasks.edit.return_value = {
             "ref": 7,
             "subject": "T",
             "status_extra_info": None,
@@ -716,8 +716,8 @@ class TestUpdateTask:
             "is_blocked": False,
         }
         wf.update_task("p", 7, sprint="Sprint 2", session_id=session)
-        payload = mock_client.api.patch.call_args.kwargs["json"]
-        assert payload["milestone"] == 33
+        kwargs = mock_client.api.tasks.edit.call_args.kwargs
+        assert kwargs["milestone"] == 33
 
     def test_no_op_raises(self, session, mock_client):
         mock_client.api.get.side_effect = self._api_get
@@ -737,7 +737,7 @@ class TestSetTaskStatus:
 
         mock_client.api.get.side_effect = api_get
         mock_client.list_resources.return_value = [{"id": 99, "name": "Done"}]
-        mock_client.api.patch.return_value = {
+        mock_client.api.tasks.edit.return_value = {
             "ref": 7,
             "status_extra_info": {"name": "Done"},
             "is_closed": True,
@@ -747,10 +747,6 @@ class TestSetTaskStatus:
         assert result["is_closed"] is True
         # Confirm uses task_statuses, not userstory_statuses.
         mock_client.list_resources.assert_called_once_with("task_statuses", project_id=1)
-        # Confirm PATCH payload carries resolved status ID and version.
-        patch_payload = mock_client.api.patch.call_args.kwargs["json"]
-        assert patch_payload["status"] == 99
-        assert patch_payload["version"] == 2
 
 
 class TestBreakDownStory:
@@ -1022,131 +1018,113 @@ class TestBreakDownStoryBulkShapeWarn:
         )
 
 
-class TestUpdateIssue:
+# ---------------------------------------------------------------------------
+# get_project_health
+# ---------------------------------------------------------------------------
+
+
+class TestGetProjectHealth:
     def _project(self):
         return {"id": 1, "slug": "p", "name": "P"}
 
-    def _issue(self):
-        return {"id": 300, "ref": 12, "version": 4}
-
-    def test_subject_and_description_patched_directly(self, session, mock_client):
-        """update_issue must bypass issues.edit() (fixed-signature) via direct PATCH."""
-        mock_client.api.issues.get_by_ref.return_value = self._issue()
-        mock_client.api.get.return_value = self._project()
-        mock_client.api.patch.return_value = {
-            "ref": 12,
-            "subject": "New subject",
-            "status_extra_info": None,
-            "priority_extra_info": None,
-            "severity_extra_info": None,
-            "type_extra_info": None,
-            "assigned_to_extra_info": None,
-            "is_blocked": False,
+    def _stats(self):
+        return {
+            "total_points": 100,
+            "closed_points": 40,
+            "assigned_points": 60,
+            "total_milestones": 3,
+            "speed": 2.5,
+            "milestones": [
+                {"name": "Sprint 1", "closed_points": 10},
+                {"name": "Sprint 2", "closed_points": 30},
+            ],
         }
-        wf.update_issue("p", 12, subject="New subject", description="desc", session_id=session)
-        payload = mock_client.api.patch.call_args.kwargs["json"]
-        assert payload["subject"] == "New subject"
-        assert payload["description"] == "desc"
-        assert payload["version"] == 4
 
-    def test_no_op_raises(self, session, mock_client):
-        mock_client.api.issues.get_by_ref.return_value = self._issue()
-        mock_client.api.get.return_value = self._project()
-        with pytest.raises(ValueError, match="No fields to update"):
-            wf.update_issue("p", 12, session_id=session)
+    def _issues_stats(self):
+        return {
+            "total_issues": 20,
+            "opened_issues": 14,
+            "closed_issues": 6,
+            "issues_per_priority": [
+                {"name": "High", "count": 5},
+                {"name": "Normal", "count": 9},
+            ],
+        }
 
+    def _modules(self):
+        return {
+            "is_backlog_activated": True,
+            "is_kanban_activated": False,
+            "is_wiki_activated": True,
+            "is_issues_activated": True,
+            "is_epics_activated": False,
+            "is_contact_activated": False,
+        }
 
-class TestAddComment:
-    def _project(self):
-        return {"id": 1, "slug": "p", "name": "P"}
-
-    def test_task_comment_uses_direct_get(self, session, mock_client):
-        """add_comment for entity_type=task must use direct GET (not tasks.get_by_ref)."""
-        task = {"id": 200, "ref": 7, "version": 3}
-
+    def _setup_mocks(self, mock_client, stats=None, issues_stats=None, modules=None):
         def api_get(path, params=None):
-            if "/tasks/by_ref" in str(path):
-                return task
+            if "/projects/by_slug" in str(path):
+                return self._project()
+            if str(path).endswith("/stats"):
+                return stats if stats is not None else self._stats()
+            if str(path).endswith("/issues_stats"):
+                return issues_stats if issues_stats is not None else self._issues_stats()
+            if str(path).endswith("/modules"):
+                return modules if modules is not None else self._modules()
             return self._project()
 
         mock_client.api.get.side_effect = api_get
-        wf.add_comment("p", 7, "hello task", entity_type="task", session_id=session)
 
-        # Verify by_ref was fetched via client.api.get, not tasks.get_by_ref
-        get_calls = [str(c.args[0]) for c in mock_client.api.get.call_args_list]
-        assert any("/tasks/by_ref" in p for p in get_calls)
-        mock_client.api.tasks.get_by_ref.assert_not_called()
+    def test_returns_story_metrics(self, session, mock_client):
+        self._setup_mocks(mock_client)
+        result = wf.get_project_health("p", session_id=session)
+        assert result["stories"]["total_points"] == 100
+        assert result["stories"]["closed_points"] == 40
+        assert result["stories"]["total_milestones"] == 3
 
-        # Verify comment was PATCHed to the correct task endpoint
-        patch_call = mock_client.api.patch.call_args
-        assert "/tasks/200" in patch_call.args[0]
-        assert patch_call.kwargs["json"]["comment"] == "hello task"
-        assert patch_call.kwargs["json"]["version"] == 3
+    def test_returns_speed(self, session, mock_client):
+        self._setup_mocks(mock_client)
+        result = wf.get_project_health("p", session_id=session)
+        assert result["stories"]["speed"] == 2.5
 
-    def test_story_comment_still_works(self, session, mock_client):
-        """add_comment for entity_type=story continues to use the same direct GET path."""
-        story = {"id": 50, "ref": 5, "version": 1}
+    def test_returns_issue_counts(self, session, mock_client):
+        self._setup_mocks(mock_client)
+        result = wf.get_project_health("p", session_id=session)
+        assert result["issues"]["total"] == 20
+        assert result["issues"]["open"] == 14
+        assert result["issues"]["closed"] == 6
+        assert result["issues"]["by_priority"]["High"] == 5
 
+    def test_returns_velocity(self, session, mock_client):
+        self._setup_mocks(mock_client)
+        result = wf.get_project_health("p", session_id=session)
+        assert len(result["velocity"]) == 2
+        assert result["velocity"][0] == {"sprint": "Sprint 1", "closed_points": 10}
+
+    def test_returns_active_modules_only(self, session, mock_client):
+        self._setup_mocks(mock_client)
+        result = wf.get_project_health("p", session_id=session)
+        assert set(result["active_modules"]) == {"backlog", "wiki", "issues"}
+        assert "kanban" not in result["active_modules"]
+
+    def test_project_info_in_response(self, session, mock_client):
+        self._setup_mocks(mock_client)
+        result = wf.get_project_health("p", session_id=session)
+        assert result["project"]["slug"] == "p"
+        assert result["project"]["id"] == 1
+
+    def test_tolerates_none_stats_and_issues_stats(self, session, mock_client):
         def api_get(path, params=None):
-            if "/userstories/by_ref" in str(path):
-                return story
+            if "/projects/by_slug" in str(path):
+                return self._project()
+            if str(path).endswith(("/stats", "/issues_stats", "/modules")):
+                return None
             return self._project()
 
         mock_client.api.get.side_effect = api_get
-        wf.add_comment("p", 5, "hello story", entity_type="story", session_id=session)
-
-        patch_call = mock_client.api.patch.call_args
-        assert "/userstories/50" in patch_call.args[0]
-        assert patch_call.kwargs["json"]["comment"] == "hello story"
-
-
-class TestAssignItem:
-    def _project(self):
-        return {"id": 1, "slug": "p", "name": "P"}
-
-    def _api_get(self, entity_path):
-        def side_effect(path, params=None):
-            if entity_path in str(path) and "by_ref" in str(path):
-                return {"id": 200, "ref": 7, "version": 2}
-            return self._project()
-
-        return side_effect
-
-    def _mock_members(self, mock_client):
-        mock_client.list_resources.return_value = [
-            {"user": 42, "user_extra_info": {"username": "alice", "full_name_display": "Alice"}}
-        ]
-
-    def test_assign_task_uses_direct_get_and_patch(self, session, mock_client):
-        """assign_item for entity_type=task must bypass tasks.get_by_ref and tasks.edit."""
-        mock_client.api.get.side_effect = self._api_get("tasks")
-        self._mock_members(mock_client)
-        mock_client.api.patch.return_value = {
-            "assigned_to_extra_info": {"full_name_display": "Alice"}
-        }
-        result = wf.assign_item("p", 7, "alice", entity_type="task", session_id=session)
-
-        mock_client.api.tasks.get_by_ref.assert_not_called()
-        mock_client.api.tasks.edit.assert_not_called()
-
-        patch_call = mock_client.api.patch.call_args
-        assert "/tasks/200" in patch_call.args[0]
-        assert patch_call.kwargs["json"]["assigned_to"] == 42
-        assert patch_call.kwargs["json"]["version"] == 2
-        assert result["assigned_to"] == "Alice"
-
-    def test_assign_issue_uses_direct_patch(self, session, mock_client):
-        """assign_item for entity_type=issue must bypass issues.edit (fixed-signature)."""
-        mock_client.api.get.side_effect = self._api_get("issues")
-        self._mock_members(mock_client)
-        mock_client.api.patch.return_value = {
-            "assigned_to_extra_info": {"full_name_display": "Alice"}
-        }
-        result = wf.assign_item("p", 7, "alice", entity_type="issue", session_id=session)
-
-        mock_client.api.issues.edit.assert_not_called()
-
-        patch_call = mock_client.api.patch.call_args
-        assert "/issues/200" in patch_call.args[0]
-        assert patch_call.kwargs["json"]["assigned_to"] == 42
-        assert result["assigned_to"] == "Alice"
+        result = wf.get_project_health("p", session_id=session)
+        assert result["stories"]["total_points"] == 0
+        assert result["stories"]["speed"] == 0
+        assert result["issues"]["total"] == 0
+        assert result["velocity"] == []
+        assert result["active_modules"] == []


### PR DESCRIPTION
## Summary

Closes #19 (partial — read-only stats tools in workflow mode).

- Adds `get_project_health(project)` to `server_workflow.py`
- Calls `GET /projects/{id}/stats`, `/issues_stats`, and `/modules` in a single tool invocation
- Returns story point completion, computed velocity speed (points/day), sprint-by-sprint velocity history, open issue counts by priority, and active modules list
- Complements `get_project_overview` (structure) with quantitative health signals — "is this project on track?"

## Test plan

- [x] 7 unit tests in `TestGetProjectHealth`: story metrics, speed, issue counts, velocity, active module filtering, project info, None-response tolerance
- [x] Full test suite: 75 passed
- [x] ruff check + format: clean