### PR TITLE
feat: add get_project_activity workflow tool

### DIFF
--- a/src/server_workflow.py
+++ b/src/server_workflow.py
@@ -1958,6 +1958,90 @@ def get_project_health(
 
 
 # ---------------------------------------------------------------------------
+# Project activity tool
+# ---------------------------------------------------------------------------
+
+# Map Taiga timeline event_type prefixes to readable entity labels.
+_TIMELINE_ENTITY_MAP = {
+    "userstories": "user_story",
+    "tasks": "task",
+    "issues": "issue",
+    "epics": "epic",
+    "milestones": "sprint",
+    "wiki": "wiki_page",
+    "projects": "project",
+}
+
+
+def _summarize_timeline_event(event: Dict[str, Any]) -> Dict[str, Any]:
+    """Distil a raw Taiga timeline event into a readable summary dict."""
+    event_type = event.get("event_type", "")
+    parts = event_type.split(".")
+    entity = _TIMELINE_ENTITY_MAP.get(parts[0], parts[0]) if parts else "unknown"
+    action = parts[-1] if len(parts) >= 2 else "unknown"
+
+    data = event.get("data") or {}
+    user_info = data.get("user") or {}
+    actor = user_info.get("name") or user_info.get("username") or "unknown"
+
+    values_diff = data.get("values_diff") or {}
+    changed_fields = list(values_diff.keys()) if values_diff else []
+
+    comment = data.get("comment") or ""
+
+    summary: Dict[str, Any] = {
+        "when": event.get("created"),
+        "actor": actor,
+        "entity": entity,
+        "action": action,
+        "object_id": event.get("object_id"),
+    }
+    if changed_fields:
+        summary["changed_fields"] = changed_fields
+    if comment:
+        summary["comment"] = comment[:200]  # truncate long comments
+    return summary
+
+
+@mcp.tool(
+    "get_project_activity",
+    description=(
+        "Return recent activity on a project — who did what to which entity and when. "
+        "Answers 'what changed today/this week?' for a PO-level audit. "
+        "limit controls how many events to return (default 20, max 100). "
+        "project accepts a slug (e.g. 'my-project') or numeric ID."
+    ),
+)
+def get_project_activity(
+    project: Any,
+    limit: int = 20,
+    session_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    actual_session_id = _get_session_id(session_id)
+    client = _get_authenticated_client(actual_session_id)
+
+    if limit < 1 or limit > 100:
+        raise ValueError("limit must be between 1 and 100.")
+
+    def do_activity():
+        proj = _resolve_project(client, project)
+        project_id = proj["id"]
+
+        raw = client.api.get(
+            f"/timeline/project/{project_id}",
+            params={"page_size": limit},
+        )
+        events = raw if isinstance(raw, list) else []
+        return {
+            "project": {"id": proj["id"], "name": proj["name"], "slug": proj["slug"]},
+            "count": len(events),
+            "events": [_summarize_timeline_event(e) for e in events],
+        }
+
+    return _execute_taiga_operation("get_project_activity", do_activity, str(project))
+
+
+# ---------------------------------------------------------------------------
 # Comment tool
 # ---------------------------------------------------------------------------
 

--- a/src/server_workflow.py
+++ b/src/server_workflow.py
@@ -1977,7 +1977,7 @@ def _summarize_timeline_event(event: Dict[str, Any]) -> Dict[str, Any]:
     """Distil a raw Taiga timeline event into a readable summary dict."""
     event_type = event.get("event_type", "")
     parts = event_type.split(".")
-    entity = _TIMELINE_ENTITY_MAP.get(parts[0], parts[0]) if parts else "unknown"
+    entity = _TIMELINE_ENTITY_MAP.get(parts[0], parts[0]) if parts[0] else "unknown"
     action = parts[-1] if len(parts) >= 2 else "unknown"
 
     data = event.get("data") or {}

--- a/tests/test_server_workflow.py
+++ b/tests/test_server_workflow.py
@@ -1128,3 +1128,96 @@ class TestGetProjectHealth:
         assert result["issues"]["total"] == 0
         assert result["velocity"] == []
         assert result["active_modules"] == []
+
+
+# ---------------------------------------------------------------------------
+# get_project_activity
+# ---------------------------------------------------------------------------
+
+
+class TestGetProjectActivity:
+    def _project(self):
+        return {"id": 1, "slug": "p", "name": "P"}
+
+    def _event(
+        self, event_type="userstories.userstory.change", actor="Alice", fields=None, comment=""
+    ):
+        return {
+            "event_type": event_type,
+            "created": "2026-06-05T10:00:00Z",
+            "object_id": 42,
+            "data": {
+                "user": {"name": actor},
+                "values_diff": {f: ["old", "new"] for f in (fields or [])},
+                "comment": comment,
+            },
+        }
+
+    def _setup(self, mock_client, events):
+        def api_get(path, params=None):
+            if "/projects/by_slug" in str(path):
+                return self._project()
+            return events
+
+        mock_client.api.get.side_effect = api_get
+
+    def test_returns_events_list(self, session, mock_client):
+        events = [self._event(fields=["status"])]
+        self._setup(mock_client, events)
+        result = wf.get_project_activity("p", session_id=session)
+        assert result["count"] == 1
+        assert result["events"][0]["entity"] == "user_story"
+        assert result["events"][0]["action"] == "change"
+        assert result["events"][0]["actor"] == "Alice"
+
+    def test_changed_fields_extracted(self, session, mock_client):
+        events = [self._event(fields=["status", "assigned_to"])]
+        self._setup(mock_client, events)
+        result = wf.get_project_activity("p", session_id=session)
+        assert "status" in result["events"][0]["changed_fields"]
+        assert "assigned_to" in result["events"][0]["changed_fields"]
+
+    def test_comment_included(self, session, mock_client):
+        events = [self._event(comment="Great progress!")]
+        self._setup(mock_client, events)
+        result = wf.get_project_activity("p", session_id=session)
+        assert result["events"][0]["comment"] == "Great progress!"
+
+    def test_comment_truncated_at_200(self, session, mock_client):
+        long_comment = "x" * 300
+        events = [self._event(comment=long_comment)]
+        self._setup(mock_client, events)
+        result = wf.get_project_activity("p", session_id=session)
+        assert len(result["events"][0]["comment"]) == 200
+
+    def test_no_changed_fields_key_when_empty(self, session, mock_client):
+        events = [self._event()]
+        self._setup(mock_client, events)
+        result = wf.get_project_activity("p", session_id=session)
+        assert "changed_fields" not in result["events"][0]
+
+    def test_entity_map_task(self, session, mock_client):
+        events = [self._event(event_type="tasks.task.create")]
+        self._setup(mock_client, events)
+        result = wf.get_project_activity("p", session_id=session)
+        assert result["events"][0]["entity"] == "task"
+        assert result["events"][0]["action"] == "create"
+
+    def test_invalid_limit_raises(self, session, mock_client):
+        with pytest.raises(ValueError, match="limit must be between"):
+            wf.get_project_activity("p", limit=0, session_id=session)
+
+    def test_limit_too_large_raises(self, session, mock_client):
+        with pytest.raises(ValueError, match="limit must be between"):
+            wf.get_project_activity("p", limit=101, session_id=session)
+
+    def test_non_list_response_coerced_to_empty(self, session, mock_client):
+        def api_get(path, params=None):
+            if "/projects/by_slug" in str(path):
+                return self._project()
+            return {"unexpected": "dict"}
+
+        mock_client.api.get.side_effect = api_get
+        result = wf.get_project_activity("p", session_id=session)
+        assert result["events"] == []
+        assert result["count"] == 0

--- a/tests/test_server_workflow.py
+++ b/tests/test_server_workflow.py
@@ -1221,3 +1221,31 @@ class TestGetProjectActivity:
         result = wf.get_project_activity("p", session_id=session)
         assert result["events"] == []
         assert result["count"] == 0
+
+    def test_actor_falls_back_to_username(self, session, mock_client):
+        event = self._event()
+        event["data"]["user"] = {"username": "bob"}
+        self._setup(mock_client, [event])
+        result = wf.get_project_activity("p", session_id=session)
+        assert result["events"][0]["actor"] == "bob"
+
+    def test_actor_unknown_when_no_user_info(self, session, mock_client):
+        event = self._event()
+        event["data"]["user"] = {}
+        self._setup(mock_client, [event])
+        result = wf.get_project_activity("p", session_id=session)
+        assert result["events"][0]["actor"] == "unknown"
+
+    def test_when_and_object_id_propagated(self, session, mock_client):
+        events = [self._event()]
+        self._setup(mock_client, events)
+        result = wf.get_project_activity("p", session_id=session)
+        assert result["events"][0]["when"] == "2026-06-05T10:00:00Z"
+        assert result["events"][0]["object_id"] == 42
+
+    def test_empty_event_type_yields_unknown_entity(self, session, mock_client):
+        event = self._event(event_type="")
+        self._setup(mock_client, [event])
+        result = wf.get_project_activity("p", session_id=session)
+        assert result["events"][0]["entity"] == "unknown"
+        assert result["events"][0]["action"] == "unknown"


### PR DESCRIPTION
## Summary

Closes #20 (project-scoped timeline only; user timeline deferred to full mode).

- Adds \`get_project_activity(project, limit=20)\` to \`server_workflow.py\`
- Calls \`GET /timeline/project/{id}\` with configurable page size (1–100)
- Summarises raw timeline events to: actor, entity type, action, changed field names, and comment excerpt (truncated at 200 chars) — raw \`data\` blob is not forwarded
- Adds \`_TIMELINE_ENTITY_MAP\` and \`_summarize_timeline_event()\` helper for event distillation
- Answers the PO question "what changed today/this week?"

## Test plan

- [x] 13 unit tests added in \`TestGetProjectActivity\` covering: event list, changed fields extraction, comment included, comment truncation at 200, no \`changed_fields\` key when empty, entity map (task), limit=0 raises, limit=101 raises, non-list response coerced to empty, username actor fallback, unknown actor, when/object_id propagation, empty event_type yields unknown entity
- [x] Full test suite: 88 passed
- [x] ruff check + format: clean