### PR TITLE
feat: add get_current_user workflow tool

### DIFF
--- a/src/server_workflow.py
+++ b/src/server_workflow.py
@@ -540,6 +540,32 @@ def session_status(session_id: Optional[str] = None) -> Dict[str, Any]:
     return {"status": "inactive", "reason": "not_found", "session_id": actual_session_id}
 
 
+@mcp.tool(
+    "get_current_user",
+    description=(
+        "Return the identity of the authenticated user for this session. "
+        "Useful when the agent needs to resolve 'me' — e.g. 'assign this to me' or 'show my tasks'. "
+        "Returns username, display name, email, and user ID."
+    ),
+)
+def get_current_user(session_id: Optional[str] = None) -> Dict[str, Any]:
+    actual_session_id = _get_session_id(session_id)
+    client = _get_authenticated_client(actual_session_id)
+
+    def do_get_me():
+        me = client.api.users.get_me()
+        return {
+            "id": me.get("id"),
+            "username": me.get("username"),
+            "full_name": me.get("full_name_display") or me.get("full_name"),
+            "email": me.get("email"),
+            "bio": me.get("bio") or None,
+            "photo": me.get("photo") or None,
+        }
+
+    return _execute_taiga_operation("get_current_user", do_get_me)
+
+
 # ---------------------------------------------------------------------------
 # Discovery tools
 # ---------------------------------------------------------------------------

--- a/tests/test_server_workflow.py
+++ b/tests/test_server_workflow.py
@@ -1249,3 +1249,58 @@ class TestGetProjectActivity:
         result = wf.get_project_activity("p", session_id=session)
         assert result["events"][0]["entity"] == "unknown"
         assert result["events"][0]["action"] == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# get_current_user
+# ---------------------------------------------------------------------------
+
+
+class TestGetCurrentUser:
+    def _me(self):
+        return {
+            "id": 42,
+            "username": "rva",
+            "full_name_display": "Romain V",
+            "full_name": "Romain Valtier",
+            "email": "rva@tetra-ai.com",
+            "bio": "Platform lead",
+            "photo": "https://cdn.example.com/rva.jpg",
+        }
+
+    def test_returns_identity_fields(self, session, mock_client):
+        mock_client.api.users.get_me.return_value = self._me()
+        result = wf.get_current_user(session_id=session)
+        assert result["id"] == 42
+        assert result["username"] == "rva"
+        assert result["full_name"] == "Romain V"
+        assert result["email"] == "rva@tetra-ai.com"
+
+    def test_prefers_full_name_display(self, session, mock_client):
+        me = self._me()
+        me["full_name_display"] = "Display Name"
+        me["full_name"] = "Other Name"
+        mock_client.api.users.get_me.return_value = me
+        result = wf.get_current_user(session_id=session)
+        assert result["full_name"] == "Display Name"
+
+    def test_falls_back_to_full_name(self, session, mock_client):
+        me = self._me()
+        me["full_name_display"] = None
+        mock_client.api.users.get_me.return_value = me
+        result = wf.get_current_user(session_id=session)
+        assert result["full_name"] == "Romain Valtier"
+
+    def test_optional_fields_none_when_missing(self, session, mock_client):
+        mock_client.api.users.get_me.return_value = {
+            "id": 1,
+            "username": "x",
+            "email": "x@example.com",
+        }
+        result = wf.get_current_user(session_id=session)
+        assert result["bio"] is None
+        assert result["photo"] is None
+
+    def test_unauthenticated_raises(self):
+        with pytest.raises((ValueError, PermissionError)):
+            wf.get_current_user(session_id="nonexistent")

--- a/uv.lock
+++ b/uv.lock
@@ -712,7 +712,7 @@ cli = [
 
 [[package]]
 name = "mcp-taiga-bridge"
-version = "1.17.0"
+version = "1.18.0"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },


### PR DESCRIPTION
## Summary

Closes #21 (partial — workflow-relevant tools only; full user profile endpoints deferred to full mode).

- Adds \`get_current_user()\` to \`server_workflow.py\`, placed in the session tools section alongside \`session_status\`
- Calls \`GET /users/me\` and returns: \`id\`, \`username\`, \`full_name\` (prefers \`full_name_display\`), \`email\`, \`bio\`, \`photo\`
- Fills the 'me' resolution gap: \`assign_item\` and similar tools accept a username string, and agents had no canonical way to resolve "me" to a user identity without relying on session state stored at login

## Test plan

- [x] 5 unit tests added in \`TestGetCurrentUser\` covering: identity fields returned, \`full_name_display\` preferred over \`full_name\`, fallback to \`full_name\`, optional fields \`None\` when missing, unauthenticated raises
- [x] Full test suite: 93 passed
- [x] ruff check + format: clean