### PR TITLE
fix: pass extra issue fields via data dict in create_issue

### DIFF
--- a/src/server_workflow.py
+++ b/src/server_workflow.py
@@ -1233,7 +1233,12 @@ def create_issue(
         if statuses:
             payload["status"] = statuses[0]["id"]
 
-        result = client.api.issues.create(**payload)
+        data = {k: v for k, v in payload.items() if k not in ("project", "subject")}
+        result = client.api.issues.create(
+            project=project_id,
+            subject=subject,
+            data=data if data else None,
+        )
         return {
             "status": "created",
             "ref": result.get("ref"),

--- a/tests/test_server_workflow.py
+++ b/tests/test_server_workflow.py
@@ -470,13 +470,17 @@ class TestCreateIssueNoneDefaultsGuard:
         }
 
         wf.create_issue("p", "Bug", session_id=session)
-        kwargs = mock_client.api.issues.create.call_args.kwargs
+        call_kwargs = mock_client.api.issues.create.call_args.kwargs
+        # Extra fields are passed via the data dict, not as direct kwargs.
+        assert call_kwargs["project"] == 1
+        assert call_kwargs["subject"] == "Bug"
+        data = call_kwargs["data"]
         # No None values should be sent to the API.
-        assert "priority" not in kwargs
-        assert "severity" not in kwargs
-        assert "type" not in kwargs
+        assert "priority" not in data
+        assert "severity" not in data
+        assert "type" not in data
         # Default status is still wired up.
-        assert kwargs["status"] == 7
+        assert data["status"] == 7
 
 
 class TestGetEpicOverviewBatched:


### PR DESCRIPTION
## Summary

- `Issues.create()` signature is `(project, subject, data=None)` — it does **not** accept extra fields as direct kwargs
- `create_issue` in `server_workflow.py` was calling `client.api.issues.create(**payload)`, which unpacked `priority`, `severity`, `type`, `status`, etc. as direct keyword arguments → `TypeError: Issues.create() got an unexpected keyword argument 'priority'`
- `server_full.py` already used the correct pattern: `issues.create(project=..., subject=..., data=issue_data)` — this fix brings workflow mode in line

## Changes

- `src/server_workflow.py`: split payload into `project`/`subject` args + `data` dict for the remaining fields
- `tests/test_server_workflow.py`: update `TestCreateIssueNoneDefaultsGuard` to assert against `call_kwargs["data"]` instead of direct call kwargs

## Test plan

- [ ] `uv run pytest tests/test_server_workflow.py tests/test_server.py` — 406 passed
- [ ] `ruff check` + `ruff format --check` — clean
- [ ] Pre-commit hooks pass (secrets, ruff, unit tests)