### PR TITLE
fix: use data dict for tasks/issues/wiki edit calls in workflow server

### DIFF
--- a/src/server_workflow.py
+++ b/src/server_workflow.py
@@ -1049,8 +1049,9 @@ def update_task(
         if len(payload) == 1:  # only version key
             raise ValueError("No fields to update were provided.")
 
-        version = payload.pop("version")
-        result = client.api.tasks.edit(current["id"], version=version, data=payload)
+        version = payload["version"]
+        data = {k: v for k, v in payload.items() if k != "version"}
+        result = client.api.tasks.edit(current["id"], version=version, data=data)
         return _task_summary(result)
 
     return _execute_taiga_operation("update_task", do_update, f"task #{ref} in {project}")
@@ -1317,8 +1318,9 @@ def update_issue(
         if len(payload) == 1:
             raise ValueError("No fields to update were provided.")
 
-        version = payload.pop("version")
-        result = client.api.issues.edit(current["id"], version=version, data=payload)
+        version = payload["version"]
+        data = {k: v for k, v in payload.items() if k != "version"}
+        result = client.api.issues.edit(current["id"], version=version, data=data)
         return {
             "ref": result.get("ref"),
             "subject": result.get("subject"),

--- a/src/server_workflow.py
+++ b/src/server_workflow.py
@@ -1049,7 +1049,8 @@ def update_task(
         if len(payload) == 1:  # only version key
             raise ValueError("No fields to update were provided.")
 
-        result = client.api.tasks.edit(current["id"], **payload)
+        version = payload.pop("version")
+        result = client.api.tasks.edit(current["id"], version=version, data=payload)
         return _task_summary(result)
 
     return _execute_taiga_operation("update_task", do_update, f"task #{ref} in {project}")
@@ -1316,7 +1317,8 @@ def update_issue(
         if len(payload) == 1:
             raise ValueError("No fields to update were provided.")
 
-        result = client.api.issues.edit(current["id"], **payload)
+        version = payload.pop("version")
+        result = client.api.issues.edit(current["id"], version=version, data=payload)
         return {
             "ref": result.get("ref"),
             "subject": result.get("subject"),
@@ -1577,7 +1579,9 @@ def set_task_status(
         if not current:
             raise ValueError(f"Task #{ref} not found in project '{proj['slug']}'.")
 
-        result = client.api.tasks.edit(current["id"], status=status_id, version=current["version"])
+        result = client.api.tasks.edit(
+            current["id"], version=current["version"], data={"status": status_id}
+        )
         return {
             "ref": ref,
             "status": (result.get("status_extra_info") or {}).get("name") or status,
@@ -1906,7 +1910,7 @@ def upsert_wiki(
         existing = client.api.get("/wiki/by_slug", params={"slug": slug, "project": project_id})
         if existing:
             result = client.api.wiki.edit(
-                existing["id"], slug=slug, content=content, version=existing["version"]
+                existing["id"], version=existing["version"], data={"slug": slug, "content": content}
             )
             return {"status": "updated", "slug": result.get("slug"), "id": result.get("id")}
         else:

--- a/tests/test_server_workflow.py
+++ b/tests/test_server_workflow.py
@@ -400,6 +400,79 @@ class TestUpsertWiki:
         mock_client.api.wiki.edit.return_value = {"id": 9, "slug": "my-page"}
         result = wf.upsert_wiki("p", "my-page", "Updated content", session_id=session)
         assert result["status"] == "updated"
+        kwargs = mock_client.api.wiki.edit.call_args.kwargs
+        assert kwargs["version"] == 3
+        assert kwargs["data"] == {"slug": "my-page", "content": "Updated content"}
+
+
+class TestUpdateIssue:
+    def _project(self):
+        return {"id": 1, "slug": "p", "name": "P"}
+
+    def _issue(self):
+        return {"id": 300, "ref": 5, "subject": "Bug", "version": 2}
+
+    def test_resolves_status_by_name(self, session, mock_client):
+        mock_client.api.get.return_value = self._project()
+        mock_client.api.issues.get_by_ref.return_value = self._issue()
+        mock_client.list_resources.return_value = [{"id": 20, "name": "In Progress"}]
+        mock_client.api.issues.edit.return_value = {
+            "ref": 5,
+            "subject": "Bug",
+            "status_extra_info": {"name": "In Progress"},
+            "priority_extra_info": None,
+            "severity_extra_info": None,
+            "type_extra_info": None,
+            "assigned_to_extra_info": None,
+            "is_blocked": False,
+        }
+        wf.update_issue("p", 5, status="In Progress", session_id=session)
+        kwargs = mock_client.api.issues.edit.call_args.kwargs
+        assert kwargs["version"] == 2
+        assert kwargs["data"]["status"] == 20
+
+    def test_resolves_priority_by_name(self, session, mock_client):
+        mock_client.api.get.return_value = self._project()
+        mock_client.api.issues.get_by_ref.return_value = self._issue()
+        mock_client.list_resources.return_value = [{"id": 3, "name": "High"}]
+        mock_client.api.issues.edit.return_value = {
+            "ref": 5,
+            "subject": "Bug",
+            "status_extra_info": None,
+            "priority_extra_info": {"name": "High"},
+            "severity_extra_info": None,
+            "type_extra_info": None,
+            "assigned_to_extra_info": None,
+            "is_blocked": False,
+        }
+        wf.update_issue("p", 5, priority="High", session_id=session)
+        kwargs = mock_client.api.issues.edit.call_args.kwargs
+        assert kwargs["version"] == 2
+        assert kwargs["data"]["priority"] == 3
+
+    def test_no_op_raises(self, session, mock_client):
+        mock_client.api.get.return_value = self._project()
+        mock_client.api.issues.get_by_ref.return_value = self._issue()
+        with pytest.raises(ValueError, match="No fields to update"):
+            wf.update_issue("p", 5, session_id=session)
+
+    def test_data_does_not_contain_version(self, session, mock_client):
+        mock_client.api.get.return_value = self._project()
+        mock_client.api.issues.get_by_ref.return_value = self._issue()
+        mock_client.list_resources.return_value = [{"id": 20, "name": "Done"}]
+        mock_client.api.issues.edit.return_value = {
+            "ref": 5,
+            "subject": "Bug",
+            "status_extra_info": {"name": "Done"},
+            "priority_extra_info": None,
+            "severity_extra_info": None,
+            "type_extra_info": None,
+            "assigned_to_extra_info": None,
+            "is_blocked": False,
+        }
+        wf.update_issue("p", 5, status="Done", session_id=session)
+        kwargs = mock_client.api.issues.edit.call_args.kwargs
+        assert "version" not in kwargs["data"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_server_workflow.py
+++ b/tests/test_server_workflow.py
@@ -691,8 +691,8 @@ class TestUpdateTask:
         }
         wf.update_task("p", 7, status="Done", session_id=session)
         kwargs = mock_client.api.tasks.edit.call_args.kwargs
-        assert kwargs["status"] == 12
         assert kwargs["version"] == 3
+        assert kwargs["data"]["status"] == 12
 
     def test_reparent_resolves_story_ref(self, session, mock_client):
         mock_client.api.get.side_effect = self._api_get
@@ -707,7 +707,7 @@ class TestUpdateTask:
         }
         wf.update_task("p", 7, story_ref=44, session_id=session)
         kwargs = mock_client.api.tasks.edit.call_args.kwargs
-        assert kwargs["user_story"] == 99
+        assert kwargs["data"]["user_story"] == 99
 
     def test_sprint_move_supported(self, session, mock_client):
         mock_client.api.get.side_effect = self._api_get
@@ -721,7 +721,7 @@ class TestUpdateTask:
         }
         wf.update_task("p", 7, sprint="Sprint 2", session_id=session)
         kwargs = mock_client.api.tasks.edit.call_args.kwargs
-        assert kwargs["milestone"] == 33
+        assert kwargs["data"]["milestone"] == 33
 
     def test_no_op_raises(self, session, mock_client):
         mock_client.api.get.side_effect = self._api_get


### PR DESCRIPTION
## Summary

Follow-up to #84 (create_issue fix). Three pytaigaclient resource types — `tasks`, `issues`, `wiki` — use `edit(id, version, data)` with no `**kwargs`, but `server_workflow.py` was calling them by unpacking extra fields directly as keyword arguments. This caused `TypeError` on any real call.

`server_full.py` already used the correct pattern (with a comment noting why); this PR brings the workflow server in line.

**Affected tools:**
- `update_task` — `tasks.edit(id, **payload)` → `tasks.edit(id, version=v, data=payload)`
- `set_task_status` — `tasks.edit(id, status=s, version=v)` → `tasks.edit(id, version=v, data={"status": s})`
- `update_issue` — `issues.edit(id, **payload)` → `issues.edit(id, version=v, data=payload)`
- `upsert_wiki` (update path) — `wiki.edit(id, slug=s, content=c, version=v)` → `wiki.edit(id, version=v, data={"slug": s, "content": c})`

## Test plan

- [ ] `uv run pytest tests/test_server_workflow.py tests/test_server.py` — 406 passed
- [ ] `ruff check` + `ruff format --check` — clean
- [ ] Pre-commit hooks pass (secrets, ruff, unit tests)