### PR TITLE
fix: give tool params typed JSON schemas instead of bare `Any`

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ The bridge provides comprehensive CRUD operations and advanced features across a
 - **Secure Credentials**: Environment variable authentication with credential protection - passwords never appear in logs or error messages
 - **Auto-Authentication**: Configure `TAIGA_USERNAME` and `TAIGA_PASSWORD` environment variables for seamless startup without manual login
 - **Input Validation**: Allowlist-based parameter validation prevents unexpected data from reaching the Taiga API
+- **Typed Tool Schemas**: Every tool parameter exposes a typed JSON schema — e.g. `project` accepts a slug or ID (`string | integer`), `kwargs`/`filters` accept a JSON object or string — so MCP clients get accurate type hints instead of an untyped parameter they might omit
 
 ### Response Filtering
 

--- a/run_unit_tests.sh
+++ b/run_unit_tests.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-# Run unit tests
-uv run pytest tests/test_server.py -v
+# Run unit tests (full + workflow servers + transport) — matches CI and the pre-commit hook
+uv run pytest tests/test_server.py tests/test_server_workflow.py tests/test_transport.py -v

--- a/src/server_full.py
+++ b/src/server_full.py
@@ -6,7 +6,7 @@ import os
 import sys
 import uuid
 from contextlib import asynccontextmanager
-from typing import Any, AsyncIterator, Dict, List, Optional
+from typing import Any, AsyncIterator, Dict, List, Optional, Union
 
 from mcp.server.fastmcp import FastMCP
 from pytaigaclient.exceptions import TaigaAPIError, TaigaException
@@ -873,7 +873,7 @@ def get_project_by_slug(
 def create_project(
     name: str,
     description: str,
-    kwargs: Any = None,
+    kwargs: Optional[Union[Dict[str, Any], str]] = None,
     session_id: Optional[str] = None,
     verbosity: str = "standard",
 ) -> Dict[str, Any]:
@@ -909,7 +909,7 @@ def create_project(
 )
 def update_project(
     project_id: int,
-    kwargs: Any = None,
+    kwargs: Optional[Union[Dict[str, Any], str]] = None,
     session_id: Optional[str] = None,
     verbosity: str = "standard",
 ) -> Dict[str, Any]:
@@ -1115,7 +1115,7 @@ def mix_project_tags(
 )
 def list_user_stories(
     project_id: int,
-    filters: Any = None,
+    filters: Optional[Union[Dict[str, Any], str]] = None,
     session_id: Optional[str] = None,
     verbosity: str = "standard",
 ) -> List[Dict[str, Any]]:
@@ -1151,7 +1151,7 @@ def list_user_stories(
 def create_user_story(
     project_id: int,
     subject: str,
-    kwargs: Any = None,
+    kwargs: Optional[Union[Dict[str, Any], str]] = None,
     session_id: Optional[str] = None,
     verbosity: str = "standard",
 ) -> Dict[str, Any]:
@@ -1240,7 +1240,7 @@ def get_user_story_by_ref(
 )
 def update_user_story(
     user_story_id: int,
-    kwargs: Any = None,
+    kwargs: Optional[Union[Dict[str, Any], str]] = None,
     session_id: Optional[str] = None,
     verbosity: str = "standard",
 ) -> Dict[str, Any]:
@@ -1365,7 +1365,7 @@ def get_user_story_statuses(
 )
 def list_tasks(
     project_id: int,
-    filters: Any = None,
+    filters: Optional[Union[Dict[str, Any], str]] = None,
     session_id: Optional[str] = None,
     verbosity: str = "standard",
 ) -> List[Dict[str, Any]]:
@@ -1401,7 +1401,7 @@ def list_tasks(
 def create_task(
     project_id: int,
     subject: str,
-    kwargs: Any = None,
+    kwargs: Optional[Union[Dict[str, Any], str]] = None,
     session_id: Optional[str] = None,
     verbosity: str = "standard",
 ) -> Dict[str, Any]:
@@ -1482,7 +1482,10 @@ def get_task_by_ref(
     ),
 )
 def update_task(
-    task_id: int, kwargs: Any = None, session_id: Optional[str] = None, verbosity: str = "standard"
+    task_id: int,
+    kwargs: Optional[Union[Dict[str, Any], str]] = None,
+    session_id: Optional[str] = None,
+    verbosity: str = "standard",
 ) -> Dict[str, Any]:
     """Updates a task. Pass fields to update as kwargs JSON string (e.g., {"subject": "New", "status": 2})."""
     actual_session_id = _get_session_id(session_id)
@@ -1597,7 +1600,7 @@ def get_task_statuses(project_id: int, session_id: Optional[str] = None) -> List
 )
 def list_issues(
     project_id: int,
-    filters: Any = None,
+    filters: Optional[Union[Dict[str, Any], str]] = None,
     session_id: Optional[str] = None,
     verbosity: str = "standard",
 ) -> List[Dict[str, Any]]:
@@ -1637,7 +1640,7 @@ def create_issue(
     status_id: int,
     severity_id: int,
     type_id: int,
-    kwargs: Any = None,
+    kwargs: Optional[Union[Dict[str, Any], str]] = None,
     session_id: Optional[str] = None,
     verbosity: str = "standard",
 ) -> Dict[str, Any]:
@@ -1711,7 +1714,10 @@ def get_issue_by_ref(
     ),
 )
 def update_issue(
-    issue_id: int, kwargs: Any = None, session_id: Optional[str] = None, verbosity: str = "standard"
+    issue_id: int,
+    kwargs: Optional[Union[Dict[str, Any], str]] = None,
+    session_id: Optional[str] = None,
+    verbosity: str = "standard",
 ) -> Dict[str, Any]:
     """Updates an issue. Pass fields to update as kwargs JSON string (e.g., {"subject": "New", "status": 2})."""
     actual_session_id = _get_session_id(session_id)
@@ -2667,7 +2673,7 @@ def delete_attachment(
 )
 def list_epics(
     project_id: int,
-    filters: Any = None,
+    filters: Optional[Union[Dict[str, Any], str]] = None,
     session_id: Optional[str] = None,
     verbosity: str = "standard",
 ) -> List[Dict[str, Any]]:
@@ -2702,7 +2708,7 @@ def list_epics(
 def create_epic(
     project_id: int,
     subject: str,
-    kwargs: Any = None,
+    kwargs: Optional[Union[Dict[str, Any], str]] = None,
     session_id: Optional[str] = None,
     verbosity: str = "standard",
 ) -> Dict[str, Any]:
@@ -2766,7 +2772,10 @@ def get_epic_by_ref(
     ),
 )
 def update_epic(
-    epic_id: int, kwargs: Any = None, session_id: Optional[str] = None, verbosity: str = "standard"
+    epic_id: int,
+    kwargs: Optional[Union[Dict[str, Any], str]] = None,
+    session_id: Optional[str] = None,
+    verbosity: str = "standard",
 ) -> Dict[str, Any]:
     """Updates an epic. Pass fields to update as kwargs JSON string (e.g., {"subject": "New", "color": "#FF0000"})."""
     actual_session_id = _get_session_id(session_id)
@@ -2977,7 +2986,7 @@ def get_milestone(
 )
 def update_milestone(
     milestone_id: int,
-    kwargs: Any = None,
+    kwargs: Optional[Union[Dict[str, Any], str]] = None,
     session_id: Optional[str] = None,
     verbosity: str = "standard",
 ) -> Dict[str, Any]:
@@ -3151,7 +3160,7 @@ def get_swimlane(
 )
 def update_swimlane(
     swimlane_id: int,
-    kwargs: Any = None,
+    kwargs: Optional[Union[Dict[str, Any], str]] = None,
     session_id: Optional[str] = None,
     verbosity: str = "standard",
 ) -> Dict[str, Any]:
@@ -3333,7 +3342,7 @@ def create_wiki_page(
     project_id: int,
     slug: str,
     content: str,
-    kwargs: Any = None,
+    kwargs: Optional[Union[Dict[str, Any], str]] = None,
     session_id: Optional[str] = None,
     verbosity: str = "standard",
 ) -> Dict[str, Any]:
@@ -3394,7 +3403,7 @@ def get_wiki_page_by_slug(
 )
 def update_wiki_page(
     wiki_page_id: int,
-    kwargs: Any = None,
+    kwargs: Optional[Union[Dict[str, Any], str]] = None,
     session_id: Optional[str] = None,
     verbosity: str = "standard",
 ) -> Dict[str, Any]:

--- a/src/server_workflow.py
+++ b/src/server_workflow.py
@@ -17,7 +17,7 @@ import sys
 import uuid
 from contextlib import asynccontextmanager
 from datetime import date
-from typing import Any, AsyncIterator, Dict, List, Optional
+from typing import Any, AsyncIterator, Dict, List, Optional, Union
 
 from mcp.server.fastmcp import FastMCP
 from pytaigaclient.exceptions import TaigaAPIError, TaigaException
@@ -603,7 +603,7 @@ def list_projects(session_id: Optional[str] = None) -> List[Dict[str, Any]]:
     ),
 )
 def get_project_overview(
-    project: Any,
+    project: Union[str, int],
     session_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     actual_session_id = _get_session_id(session_id)
@@ -678,7 +678,7 @@ def get_project_overview(
     ),
 )
 def search(
-    project: Any,
+    project: Union[str, int],
     query: str,
     session_id: Optional[str] = None,
 ) -> Dict[str, Any]:
@@ -716,7 +716,7 @@ def search(
     ),
 )
 def browse_backlog(
-    project: Any,
+    project: Union[str, int],
     status: Optional[str] = None,
     assignee: Optional[str] = None,
     epic: Optional[int] = None,
@@ -760,11 +760,11 @@ def browse_backlog(
     ),
 )
 def create_story(
-    project: Any,
+    project: Union[str, int],
     subject: str,
     description: Optional[str] = None,
     assignee: Optional[str] = None,
-    sprint: Optional[Any] = None,
+    sprint: Optional[Union[str, int]] = None,
     epic: Optional[int] = None,
     tags: Optional[List[str]] = None,
     session_id: Optional[str] = None,
@@ -821,13 +821,13 @@ def create_story(
     ),
 )
 def update_story(
-    project: Any,
+    project: Union[str, int],
     ref: int,
     subject: Optional[str] = None,
     description: Optional[str] = None,
     status: Optional[str] = None,
     assignee: Optional[str] = None,
-    sprint: Optional[Any] = None,
+    sprint: Optional[Union[str, int]] = None,
     epic: Optional[int] = None,
     tags: Optional[List[str]] = None,
     blocked: Optional[bool] = None,
@@ -921,13 +921,13 @@ def update_story(
     ),
 )
 def create_task(
-    project: Any,
+    project: Union[str, int],
     story_ref: int,
     subject: str,
     description: Optional[str] = None,
     status: Optional[str] = None,
     assignee: Optional[str] = None,
-    sprint: Optional[Any] = None,
+    sprint: Optional[Union[str, int]] = None,
     due_date: Optional[str] = None,
     tags: Optional[List[str]] = None,
     blocked: Optional[bool] = None,
@@ -997,13 +997,13 @@ def create_task(
     ),
 )
 def update_task(
-    project: Any,
+    project: Union[str, int],
     ref: int,
     subject: Optional[str] = None,
     description: Optional[str] = None,
     status: Optional[str] = None,
     assignee: Optional[str] = None,
-    sprint: Optional[Any] = None,
+    sprint: Optional[Union[str, int]] = None,
     story_ref: Optional[int] = None,
     blocked: Optional[bool] = None,
     tags: Optional[List[str]] = None,
@@ -1072,7 +1072,7 @@ def update_task(
     ),
 )
 def break_down_story(
-    project: Any,
+    project: Union[str, int],
     story_ref: int,
     tasks: List[Any],
     session_id: Optional[str] = None,
@@ -1182,7 +1182,7 @@ def break_down_story(
     ),
 )
 def create_issue(
-    project: Any,
+    project: Union[str, int],
     subject: str,
     description: Optional[str] = None,
     issue_type: Optional[str] = None,
@@ -1263,7 +1263,7 @@ def create_issue(
     ),
 )
 def update_issue(
-    project: Any,
+    project: Union[str, int],
     ref: int,
     subject: Optional[str] = None,
     description: Optional[str] = None,
@@ -1350,8 +1350,8 @@ def update_issue(
     ),
 )
 def get_sprint_board(
-    project: Any,
-    sprint: Optional[Any] = None,
+    project: Union[str, int],
+    sprint: Optional[Union[str, int]] = None,
     with_tasks: bool = True,
     session_id: Optional[str] = None,
 ) -> Dict[str, Any]:
@@ -1424,7 +1424,7 @@ def get_sprint_board(
     ),
 )
 def plan_sprint(
-    project: Any,
+    project: Union[str, int],
     name: str,
     start_date: str,
     end_date: str,
@@ -1483,9 +1483,9 @@ def plan_sprint(
     ),
 )
 def move_to_sprint(
-    project: Any,
+    project: Union[str, int],
     story_refs: List[int],
-    sprint: Any,
+    sprint: Union[str, int],
     session_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     actual_session_id = _get_session_id(session_id)
@@ -1525,7 +1525,7 @@ def move_to_sprint(
     ),
 )
 def set_story_status(
-    project: Any,
+    project: Union[str, int],
     ref: int,
     status: str,
     session_id: Optional[str] = None,
@@ -1562,7 +1562,7 @@ def set_story_status(
     ),
 )
 def set_task_status(
-    project: Any,
+    project: Union[str, int],
     ref: int,
     status: str,
     session_id: Optional[str] = None,
@@ -1602,8 +1602,8 @@ def set_task_status(
     ),
 )
 def close_sprint(
-    project: Any,
-    sprint: Optional[Any] = None,
+    project: Union[str, int],
+    sprint: Optional[Union[str, int]] = None,
     session_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     actual_session_id = _get_session_id(session_id)
@@ -1639,7 +1639,7 @@ def close_sprint(
     ),
 )
 def get_epic_overview(
-    project: Any,
+    project: Union[str, int],
     ref: int,
     session_id: Optional[str] = None,
 ) -> Dict[str, Any]:
@@ -1692,7 +1692,7 @@ def get_epic_overview(
     ),
 )
 def create_epic(
-    project: Any,
+    project: Union[str, int],
     subject: str,
     description: Optional[str] = None,
     assignee: Optional[str] = None,
@@ -1751,8 +1751,8 @@ def create_epic(
     ),
 )
 def get_team_workload(
-    project: Any,
-    sprint: Optional[Any] = None,
+    project: Union[str, int],
+    sprint: Optional[Union[str, int]] = None,
     session_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     actual_session_id = _get_session_id(session_id)
@@ -1810,7 +1810,7 @@ def get_team_workload(
     ),
 )
 def assign_item(
-    project: Any,
+    project: Union[str, int],
     ref: int,
     username: str,
     entity_type: str = "story",
@@ -1866,7 +1866,7 @@ def assign_item(
     ),
 )
 def get_wiki(
-    project: Any,
+    project: Union[str, int],
     slug: Optional[str] = None,
     session_id: Optional[str] = None,
 ) -> Any:
@@ -1897,7 +1897,7 @@ def get_wiki(
     ),
 )
 def upsert_wiki(
-    project: Any,
+    project: Union[str, int],
     slug: str,
     content: str,
     session_id: Optional[str] = None,
@@ -1938,7 +1938,7 @@ def upsert_wiki(
     ),
 )
 def get_project_health(
-    project: Any,
+    project: Union[str, int],
     session_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     actual_session_id = _get_session_id(session_id)
@@ -2050,7 +2050,7 @@ def _summarize_timeline_event(event: Dict[str, Any]) -> Dict[str, Any]:
     ),
 )
 def get_project_activity(
-    project: Any,
+    project: Union[str, int],
     limit: int = 20,
     session_id: Optional[str] = None,
 ) -> Dict[str, Any]:
@@ -2092,7 +2092,7 @@ def get_project_activity(
     ),
 )
 def add_comment(
-    project: Any,
+    project: Union[str, int],
     ref: int,
     text: str,
     entity_type: str = "story",

--- a/src/server_workflow.py
+++ b/src/server_workflow.py
@@ -1074,7 +1074,7 @@ def update_task(
 def break_down_story(
     project: Union[str, int],
     story_ref: int,
-    tasks: List[Any],
+    tasks: List[Union[str, Dict[str, Any]]],
     session_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     if not tasks:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import uuid
 from unittest.mock import MagicMock, patch
@@ -14,29 +15,40 @@ TEST_USERNAME = "test_user"
 TEST_PASSWORD = "test_password"
 
 
+def _schema_is_typed(prop: dict) -> bool:
+    """Whether a JSON-schema fragment carries usable type info.
+
+    A bare `Any` annotation generates an empty `{}` schema (no `type`), and
+    `List[Any]` generates a typed array whose `items` are an empty `{}` — both give
+    MCP clients no information. A fragment is considered typed when it has a `type`
+    (with array `items` recursively typed) or a fully-typed `anyOf`. Object schemas
+    are accepted as-is: `Dict[str, Any]` legitimately allows arbitrary values.
+    """
+    any_of = prop.get("anyOf")
+    if any_of:
+        return all(_schema_is_typed(sub) for sub in any_of)
+    schema_type = prop.get("type")
+    if schema_type is None:
+        return False
+    if schema_type == "array":
+        return _schema_is_typed(prop.get("items", {}))
+    return True
+
+
 def test_tool_params_have_typed_schemas():
     """Every full-server tool parameter must expose a typed JSON schema.
 
-    A bare `Any` annotation generates an empty `{}` schema (no `type`), giving MCP
-    clients no type information. The `kwargs`/`filters` params accept either a JSON
-    object or a JSON string, so they should resolve to a typed `anyOf`, never `{}`.
-    Guards against reintroducing `Any` on a tool signature.
+    Guards against reintroducing `Any` (or `List[Any]`) on a tool signature. The
+    `kwargs`/`filters` params accept either a JSON object or a JSON string, so they
+    resolve to a typed `anyOf`, never `{}`.
     """
-    import asyncio
-
-    def has_type(prop: dict) -> bool:
-        if "type" in prop:
-            return True
-        any_of = prop.get("anyOf")
-        return bool(any_of) and all("type" in sub for sub in any_of)
-
     tools = asyncio.run(src_server.mcp.list_tools())
     assert tools, "expected the full server to expose tools"
     offenders = [
         f"{tool.name}.{name}: {prop}"
         for tool in tools
         for name, prop in (tool.inputSchema or {}).get("properties", {}).items()
-        if name != "session_id" and not has_type(prop)
+        if name != "session_id" and not _schema_is_typed(prop)
     ]
     assert not offenders, "untyped (Any) tool params found:\n" + "\n".join(offenders)
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -15,7 +15,7 @@ TEST_USERNAME = "test_user"
 TEST_PASSWORD = "test_password"
 
 
-def _schema_is_typed(prop: dict) -> bool:
+def _schema_is_typed(prop) -> bool:
     """Whether a JSON-schema fragment carries usable type info.
 
     A bare `Any` annotation generates an empty `{}` schema (no `type`), and
@@ -24,9 +24,16 @@ def _schema_is_typed(prop: dict) -> bool:
     (with array `items` recursively typed) or a fully-typed `anyOf`. Object schemas
     are accepted as-is: `Dict[str, Any]` legitimately allows arbitrary values.
     """
+    # Non-dict fragments are constraints, not gaps — e.g. a tuple's closed
+    # `items: false`. Treat as typed so the recursion can't crash on them.
+    if not isinstance(prop, dict):
+        return True
     any_of = prop.get("anyOf")
     if any_of:
         return all(_schema_is_typed(sub) for sub in any_of)
+    # $ref (nested model), enum/const (Literal) all carry type info without a `type`.
+    if any(key in prop for key in ("$ref", "enum", "const")):
+        return True
     schema_type = prop.get("type")
     if schema_type is None:
         return False

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -14,6 +14,33 @@ TEST_USERNAME = "test_user"
 TEST_PASSWORD = "test_password"
 
 
+def test_tool_params_have_typed_schemas():
+    """Every full-server tool parameter must expose a typed JSON schema.
+
+    A bare `Any` annotation generates an empty `{}` schema (no `type`), giving MCP
+    clients no type information. The `kwargs`/`filters` params accept either a JSON
+    object or a JSON string, so they should resolve to a typed `anyOf`, never `{}`.
+    Guards against reintroducing `Any` on a tool signature.
+    """
+    import asyncio
+
+    def has_type(prop: dict) -> bool:
+        if "type" in prop:
+            return True
+        any_of = prop.get("anyOf")
+        return bool(any_of) and all("type" in sub for sub in any_of)
+
+    tools = asyncio.run(src_server.mcp.list_tools())
+    assert tools, "expected the full server to expose tools"
+    offenders = [
+        f"{tool.name}.{name}: {prop}"
+        for tool in tools
+        for name, prop in (tool.inputSchema or {}).get("properties", {}).items()
+        if name != "session_id" and not has_type(prop)
+    ]
+    assert not offenders, "untyped (Any) tool params found:\n" + "\n".join(offenders)
+
+
 # ─── Helper fixtures ──────────────────────────────────────────────────
 
 

--- a/tests/test_server_workflow.py
+++ b/tests/test_server_workflow.py
@@ -38,6 +38,44 @@ def mock_client():
 
 
 # ---------------------------------------------------------------------------
+# Tool input-schema typing (regression for empty `Any` schemas)
+# ---------------------------------------------------------------------------
+
+
+def _schema_has_type(prop: dict) -> bool:
+    """A property schema carries usable type info if it has `type` or a typed `anyOf`."""
+    if "type" in prop:
+        return True
+    any_of = prop.get("anyOf")
+    if any_of:
+        return all("type" in sub for sub in any_of)
+    return False
+
+
+def test_tool_params_have_typed_schemas():
+    """Every tool parameter must expose a typed JSON schema.
+
+    A bare `Any` annotation generates an empty `{}` schema (no `type`), which gives
+    MCP clients no information about the parameter and makes argument omission far
+    more likely — especially for required params like `project`. This guards against
+    reintroducing `Any` on a tool signature.
+    """
+    import asyncio
+
+    tools = asyncio.run(wf.mcp.list_tools())
+    assert tools, "expected the workflow server to expose tools"
+    offenders = []
+    for tool in tools:
+        props = (tool.inputSchema or {}).get("properties", {})
+        for name, prop in props.items():
+            if name == "session_id":
+                continue
+            if not _schema_has_type(prop):
+                offenders.append(f"{tool.name}.{name}: {prop}")
+    assert not offenders, "untyped (Any) tool params found:\n" + "\n".join(offenders)
+
+
+# ---------------------------------------------------------------------------
 # Session helpers
 # ---------------------------------------------------------------------------
 

--- a/tests/test_server_workflow.py
+++ b/tests/test_server_workflow.py
@@ -1,5 +1,6 @@
 """Unit tests for server_workflow.py — name resolution helpers and tool smoke tests."""
 
+import asyncio
 import uuid
 from unittest.mock import MagicMock
 
@@ -42,36 +43,54 @@ def mock_client():
 # ---------------------------------------------------------------------------
 
 
-def _schema_has_type(prop: dict) -> bool:
-    """A property schema carries usable type info if it has `type` or a typed `anyOf`."""
-    if "type" in prop:
-        return True
+def _schema_is_typed(prop: dict) -> bool:
+    """Whether a JSON-schema fragment carries usable type info.
+
+    A bare `Any` annotation generates an empty `{}` schema (no `type`), and
+    `List[Any]` generates a typed array whose `items` are an empty `{}` — both give
+    MCP clients no information. A fragment is considered typed when it has a `type`
+    (with array `items` recursively typed) or a fully-typed `anyOf`. Object schemas
+    are accepted as-is: `Dict[str, Any]` legitimately allows arbitrary values.
+    """
     any_of = prop.get("anyOf")
     if any_of:
-        return all("type" in sub for sub in any_of)
-    return False
+        return all(_schema_is_typed(sub) for sub in any_of)
+    schema_type = prop.get("type")
+    if schema_type is None:
+        return False
+    if schema_type == "array":
+        return _schema_is_typed(prop.get("items", {}))
+    return True
+
+
+def test_schema_is_typed_detects_gaps():
+    """The guard must reject empty and `List[Any]`-style item gaps, accept real types."""
+    # Untyped — must be rejected.
+    assert not _schema_is_typed({})  # Any
+    assert not _schema_is_typed({"type": "array", "items": {}})  # List[Any]
+    assert not _schema_is_typed({"anyOf": [{"type": "string"}, {}]})  # Union[str, Any]
+    # Typed — must be accepted.
+    assert _schema_is_typed({"type": "string"})
+    assert _schema_is_typed({"anyOf": [{"type": "string"}, {"type": "integer"}]})
+    assert _schema_is_typed({"type": "array", "items": {"type": "string"}})
+    assert _schema_is_typed({"type": "object", "additionalProperties": True})  # Dict[str, Any]
 
 
 def test_tool_params_have_typed_schemas():
     """Every tool parameter must expose a typed JSON schema.
 
-    A bare `Any` annotation generates an empty `{}` schema (no `type`), which gives
-    MCP clients no information about the parameter and makes argument omission far
-    more likely — especially for required params like `project`. This guards against
-    reintroducing `Any` on a tool signature.
+    Guards against reintroducing `Any` (or `List[Any]`) on a tool signature, which
+    would strip type information clients rely on to populate args — especially for
+    required params like `project`.
     """
-    import asyncio
-
     tools = asyncio.run(wf.mcp.list_tools())
     assert tools, "expected the workflow server to expose tools"
-    offenders = []
-    for tool in tools:
-        props = (tool.inputSchema or {}).get("properties", {})
-        for name, prop in props.items():
-            if name == "session_id":
-                continue
-            if not _schema_has_type(prop):
-                offenders.append(f"{tool.name}.{name}: {prop}")
+    offenders = [
+        f"{tool.name}.{name}: {prop}"
+        for tool in tools
+        for name, prop in (tool.inputSchema or {}).get("properties", {}).items()
+        if name != "session_id" and not _schema_is_typed(prop)
+    ]
     assert not offenders, "untyped (Any) tool params found:\n" + "\n".join(offenders)
 
 

--- a/tests/test_server_workflow.py
+++ b/tests/test_server_workflow.py
@@ -43,7 +43,7 @@ def mock_client():
 # ---------------------------------------------------------------------------
 
 
-def _schema_is_typed(prop: dict) -> bool:
+def _schema_is_typed(prop) -> bool:
     """Whether a JSON-schema fragment carries usable type info.
 
     A bare `Any` annotation generates an empty `{}` schema (no `type`), and
@@ -52,9 +52,16 @@ def _schema_is_typed(prop: dict) -> bool:
     (with array `items` recursively typed) or a fully-typed `anyOf`. Object schemas
     are accepted as-is: `Dict[str, Any]` legitimately allows arbitrary values.
     """
+    # Non-dict fragments are constraints, not gaps — e.g. a tuple's closed
+    # `items: false`. Treat as typed so the recursion can't crash on them.
+    if not isinstance(prop, dict):
+        return True
     any_of = prop.get("anyOf")
     if any_of:
         return all(_schema_is_typed(sub) for sub in any_of)
+    # $ref (nested model), enum/const (Literal) all carry type info without a `type`.
+    if any(key in prop for key in ("$ref", "enum", "const")):
+        return True
     schema_type = prop.get("type")
     if schema_type is None:
         return False
@@ -74,6 +81,12 @@ def test_schema_is_typed_detects_gaps():
     assert _schema_is_typed({"anyOf": [{"type": "string"}, {"type": "integer"}]})
     assert _schema_is_typed({"type": "array", "items": {"type": "string"}})
     assert _schema_is_typed({"type": "object", "additionalProperties": True})  # Dict[str, Any]
+    # Shapes without a top-level `type` that still carry info — must be accepted,
+    # and must not crash the recursion.
+    assert _schema_is_typed({"$ref": "#/$defs/Foo"})  # nested model
+    assert _schema_is_typed({"enum": ["a", "b"]})  # Literal
+    assert _schema_is_typed({"const": "x"})
+    assert _schema_is_typed({"type": "array", "prefixItems": [{"type": "string"}], "items": False})
 
 
 def test_tool_params_have_typed_schemas():


### PR DESCRIPTION
## Problem

Every workflow-server tool declares `project: Any` (and `sprint: Optional[Any]`); the full server declares `kwargs`/`filters: Any`. A bare `Any` annotation makes pydantic/FastMCP emit an **empty** input schema for that parameter — literally just `{"title": "Project"}`, with no `type`:

```python
>>> TypeAdapter(Any).json_schema()
{}
>>> TypeAdapter(Union[str, int]).json_schema()
{'anyOf': [{'type': 'string'}, {'type': 'integer'}]}
```

An empty schema gives the MCP client zero type information about the parameter. For a **required** param like `project` this makes argument omission far more likely — the client has nothing to populate, the server receives `{}`, and the call fails with `project Field required [input_value={}]`. (Note: the empty schema doesn't *hard-strip* the argument — a client can still populate a typeless param — so this is a robustness/correctness fix, not a guaranteed-repro bug.)

## Fix

**Workflow server (`server_workflow.py`)** — all ~28 intent tools:
- `project: Any` → `project: Union[str, int]`
- `sprint: Optional[Any]` → `sprint: Optional[Union[str, int]]`
- `_resolve_project` / `_resolve_sprint` helpers keep `Any` (they don't generate schemas; narrowing is churn with no payoff).

**Full server (`server_full.py`)** — 18 occurrences:
- `kwargs` / `filters: Any` → `Optional[Union[Dict[str, Any], str]]`
- The `str` arm is **deliberately retained**: clients pass these as JSON strings (handled by `_parse_mcp_kwargs`, and exercised by existing tests e.g. `kwargs="{}"`). Narrowing to `Dict` would make FastMCP's pydantic layer reject string input *before* the parser runs.
- The full server had no `project: Any` defect — its project refs are already `int`-typed — so this is the lesser schema-quality improvement on optional params.

Resulting schemas:

| param | before | after |
|---|---|---|
| `project` | `{"title":"Project"}` | `{"anyOf":[{"type":"string"},{"type":"integer"}],"title":"Project"}` |
| `sprint` | `{"anyOf":[{},{"type":"null"}],...}` | `{"anyOf":[{"type":"string"},{"type":"integer"},{"type":"null"}],...}` |
| `kwargs` | `{"title":"Kwargs"}` | `{"anyOf":[{"type":"object",...},{"type":"string"},{"type":"null"}],...}` |

## Tests

- Adds `test_tool_params_have_typed_schemas` to **both** `tests/test_server.py` and `tests/test_server_workflow.py`, asserting every tool param exposes a typed schema (`type` or a fully-typed `anyOf`). Guards against reintroducing `Any` on a tool signature.
- Full suite green: **423 passed** (3 integration deselected). Verified all 107 full-server tools + all workflow tools now have 0 untyped params.
- `ruff check` + `ruff format` clean.