### PR TITLE
fix: eliminate pytaigaclient query_params bug class — add_comment tasks + 3 latent Tasks methods (#87)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         run: uv sync --all-extras --dev
 
       - name: Run unit tests
-        run: uv run pytest tests/test_server.py tests/test_server_workflow.py tests/test_transport.py -v --tb=short
+        run: uv run pytest tests/test_server.py tests/test_server_workflow.py tests/test_taiga_client.py tests/test_transport.py -v --tb=short
 
   lint:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     hooks:
       - id: pytest
         name: unit tests
-        entry: uv run --no-sync pytest tests/test_server.py tests/test_server_workflow.py tests/test_transport.py -v --tb=short
+        entry: uv run --no-sync pytest tests/test_server.py tests/test_server_workflow.py tests/test_taiga_client.py tests/test_transport.py -v --tb=short
         language: system
         pass_filenames: false
         always_run: true

--- a/run_unit_tests.sh
+++ b/run_unit_tests.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-# Run unit tests (full + workflow servers + transport) — matches CI and the pre-commit hook
-uv run pytest tests/test_server.py tests/test_server_workflow.py tests/test_transport.py -v
+# Run unit tests (full + workflow servers + client shim + transport) — matches CI and the pre-commit hook
+uv run pytest tests/test_server.py tests/test_server_workflow.py tests/test_taiga_client.py tests/test_transport.py -v

--- a/src/server_workflow.py
+++ b/src/server_workflow.py
@@ -2114,16 +2114,17 @@ def add_comment(
         project_id = proj["id"]
         path_segment = _COMMENT_PATH_MAP[entity_type]
 
-        # Resolve ref → ID
-        collection_name = {
-            "story": "user_stories",
-            "user_story": "user_stories",
-            "task": "tasks",
-            "issue": "issues",
-            "epic": "epics",
-        }[entity_type]
-        collection = getattr(client.api, collection_name)
-        current = collection.get_by_ref(ref=ref, project=project_id)
+        # Resolve ref → ID via the by_ref endpoint directly. We bypass the
+        # pytaigaclient <resource>.get_by_ref() helpers because tasks.get_by_ref
+        # forwards a `query_params=` kwarg that TaigaClient._request() rejects
+        # ("unexpected keyword argument 'query_params'"), killing the task
+        # comment path — see issue #87 (regression of #79). Hitting the endpoint
+        # directly is version-independent and matches the update_task workaround.
+        # path_segment ("userstories"/"tasks"/"issues"/"epics") doubles as the
+        # by_ref route prefix; project_id is always an int so no slug-param quirks.
+        current = client.api.get(
+            f"/{path_segment}/by_ref", params={"ref": ref, "project": project_id}
+        )
         if not current:
             raise ValueError(f"{entity_type.capitalize()} #{ref} not found in '{proj['slug']}'.")
 

--- a/src/taiga_client.py
+++ b/src/taiga_client.py
@@ -44,7 +44,7 @@ class _CompatTaigaClient(TaigaClient):
     correctly-written callers (no ``query_params`` kwarg → nothing to remap).
     """
 
-    def get(self, path, params=None, **kwargs):
+    def get(self, path: str, params: Optional[Dict[str, Any]] = None, **kwargs: Any) -> Any:
         if "query_params" in kwargs:
             query_params = kwargs.pop("query_params")
             if params is None:

--- a/src/taiga_client.py
+++ b/src/taiga_client.py
@@ -30,6 +30,32 @@ _RESOURCE_ENDPOINTS = {
 _NO_PAGINATION_HEADERS = {"x-disable-pagination": "True"}
 
 
+class _CompatTaigaClient(TaigaClient):
+    """TaigaClient with a compatibility shim for pytaigaclient's `query_params` bug.
+
+    Four Tasks methods — `list`, `get_by_ref`, `filters_data`, `list_attachments` —
+    call ``self.client.get(endpoint, query_params=...)``, but ``TaigaClient.get``
+    only accepts ``params=`` and forwards unknown kwargs into ``_request()``, which
+    raises ``unexpected keyword argument 'query_params'``. Every other resource
+    correctly uses ``params=``, so the defect is isolated to the Tasks resource
+    (see issue #87, regression of #79). We can't patch the dependency — it's pinned
+    to an upstream commit of talhaorak/pyTaigaClient — so we remap the stray kwarg
+    here, at the one chokepoint every resource routes through. This is a no-op for
+    correctly-written callers (no ``query_params`` kwarg → nothing to remap).
+    """
+
+    def get(self, path, params=None, **kwargs):
+        if "query_params" in kwargs:
+            query_params = kwargs.pop("query_params")
+            if params is None:
+                params = query_params
+            elif query_params:
+                # Explicit params win on key conflict; never reached from the
+                # library (its buggy calls only pass query_params), but defensive.
+                params = {**query_params, **params}
+        return super().get(path, params=params, **kwargs)
+
+
 class TaigaClientWrapper:
     """
     A wrapper around the pytaiga-client library to manage API instance
@@ -53,8 +79,8 @@ class TaigaClientWrapper:
         try:
             # SECURITY: Don't log username to avoid credential exposure
             logger.info(f"Attempting login on {self.host}")
-            # Initialize the client here
-            api_instance = TaigaClient(host=self.host)
+            # Initialize the client here (compat subclass; see _CompatTaigaClient).
+            api_instance = _CompatTaigaClient(host=self.host)
             # Use the auth resource's login method
             api_instance.auth.login(username=username, password=password)
             self.api = api_instance
@@ -75,7 +101,7 @@ class TaigaClientWrapper:
     # Add method for token authentication if needed by pytaigaclient
     # def set_token(self, token: str, token_type: str = "Bearer"):
     #     logger.info(f"Initializing TaigaClient with token on {self.host}")
-    #     self.api = TaigaClient(host=self.host, auth_token=token, token_type=token_type)
+    #     self.api = _CompatTaigaClient(host=self.host, auth_token=token, token_type=token_type)
     #     logger.info("TaigaClient initialized with token.")
 
     @property

--- a/tests/test_server_workflow.py
+++ b/tests/test_server_workflow.py
@@ -896,6 +896,72 @@ class TestSetTaskStatus:
         mock_client.list_resources.assert_called_once_with("task_statuses", project_id=1)
 
 
+class TestAddComment:
+    """Regression guard for #87 — the task comment path must resolve ref→ID via
+    the /tasks/by_ref endpoint with `params=`, NOT via tasks.get_by_ref() (which
+    forwards a `query_params=` kwarg TaigaClient._request() rejects)."""
+
+    def _project(self):
+        return {"id": 1, "slug": "p", "name": "P"}
+
+    def test_task_comment_uses_by_ref_endpoint_not_helper(self, session, mock_client):
+        task = {"id": 200, "ref": 7, "version": 3}
+
+        def api_get(path, params=None):
+            if "/tasks/by_ref" in str(path):
+                return task
+            return self._project()
+
+        mock_client.api.get.side_effect = api_get
+
+        result = wf.add_comment("p", 7, "looks good", entity_type="task", session_id=session)
+
+        assert result == {"status": "comment_added", "entity_type": "task", "ref": 7}
+        # ref→ID resolution went through the raw endpoint with params=, not the helper.
+        mock_client.api.get.assert_any_call("/tasks/by_ref", params={"ref": 7, "project": 1})
+        mock_client.api.tasks.get_by_ref.assert_not_called()
+        # Comment posted to the task PATCH route with version for optimistic concurrency.
+        mock_client.api.patch.assert_called_once_with(
+            "/tasks/200", json={"comment": "looks good", "version": 3}
+        )
+
+    def test_story_comment_uses_userstories_by_ref(self, session, mock_client):
+        story = {"id": 50, "ref": 12, "version": 1}
+
+        def api_get(path, params=None):
+            if "/userstories/by_ref" in str(path):
+                return story
+            return self._project()
+
+        mock_client.api.get.side_effect = api_get
+
+        wf.add_comment("p", 12, "ship it", entity_type="story", session_id=session)
+
+        mock_client.api.get.assert_any_call("/userstories/by_ref", params={"ref": 12, "project": 1})
+        mock_client.api.user_stories.get_by_ref.assert_not_called()
+        mock_client.api.patch.assert_called_once_with(
+            "/userstories/50", json={"comment": "ship it", "version": 1}
+        )
+
+    def test_raises_when_entity_not_found(self, session, mock_client):
+        def api_get(path, params=None):
+            if "/tasks/by_ref" in str(path):
+                return None
+            return self._project()
+
+        mock_client.api.get.side_effect = api_get
+        with pytest.raises(ValueError, match="Task #7 not found"):
+            wf.add_comment("p", 7, "x", entity_type="task", session_id=session)
+
+    def test_rejects_invalid_entity_type(self, session, mock_client):
+        with pytest.raises(ValueError, match="Invalid entity_type"):
+            wf.add_comment("p", 7, "x", entity_type="bogus", session_id=session)
+
+    def test_rejects_empty_text(self, session, mock_client):
+        with pytest.raises(ValueError, match="must not be empty"):
+            wf.add_comment("p", 7, "   ", entity_type="task", session_id=session)
+
+
 class TestBreakDownStory:
     def _project(self):
         return {"id": 1, "slug": "p", "name": "P"}

--- a/tests/test_server_workflow.py
+++ b/tests/test_server_workflow.py
@@ -943,6 +943,33 @@ class TestAddComment:
             "/userstories/50", json={"comment": "ship it", "version": 1}
         )
 
+    @pytest.mark.parametrize(
+        "entity_type,segment",
+        [
+            ("user_story", "userstories"),  # alias of "story"
+            ("issue", "issues"),
+            ("epic", "epics"),
+        ],
+    )
+    def test_remaining_entity_types_route_uniformly(
+        self, session, mock_client, entity_type, segment
+    ):
+        item = {"id": 99, "ref": 5, "version": 2}
+
+        def api_get(path, params=None):
+            if f"/{segment}/by_ref" in str(path):
+                return item
+            return self._project()
+
+        mock_client.api.get.side_effect = api_get
+
+        wf.add_comment("p", 5, "note", entity_type=entity_type, session_id=session)
+
+        mock_client.api.get.assert_any_call(f"/{segment}/by_ref", params={"ref": 5, "project": 1})
+        mock_client.api.patch.assert_called_once_with(
+            f"/{segment}/99", json={"comment": "note", "version": 2}
+        )
+
     def test_raises_when_entity_not_found(self, session, mock_client):
         def api_get(path, params=None):
             if "/tasks/by_ref" in str(path):

--- a/tests/test_taiga_client.py
+++ b/tests/test_taiga_client.py
@@ -1,0 +1,81 @@
+"""Unit tests for taiga_client.py — the _CompatTaigaClient query_params shim (#87)."""
+
+from unittest.mock import patch
+
+from src.taiga_client import _CompatTaigaClient
+
+
+def _client():
+    # Constructor does no network I/O — it only builds a session + resource objects.
+    return _CompatTaigaClient(host="https://taiga.example")
+
+
+class TestCompatTaigaClientGet:
+    """Regression guard for #87 — pytaigaclient's Tasks methods call
+    get(endpoint, query_params=...), which the base TaigaClient.get rejects. The
+    shim remaps that stray kwarg onto params= for every resource at one chokepoint."""
+
+    def test_remaps_query_params_to_params(self):
+        c = _client()
+        with patch.object(_CompatTaigaClient, "_request", return_value={"ok": True}) as req:
+            result = c.get("/tasks/by_ref", query_params={"ref": 7, "project": 1})
+        assert result == {"ok": True}
+        assert req.call_args.kwargs["params"] == {"ref": 7, "project": 1}
+        assert "query_params" not in req.call_args.kwargs
+
+    def test_params_passthrough_unaffected(self):
+        c = _client()
+        with patch.object(_CompatTaigaClient, "_request", return_value=[]) as req:
+            c.get("/userstories", params={"project": 1})
+        assert req.call_args.kwargs["params"] == {"project": 1}
+        assert "query_params" not in req.call_args.kwargs
+
+    def test_no_params_at_all_passes_none(self):
+        c = _client()
+        with patch.object(_CompatTaigaClient, "_request", return_value=None) as req:
+            c.get("/tasks")  # mirrors tasks.list() with query_params=None
+        assert req.call_args.kwargs["params"] is None
+
+    def test_explicit_params_win_on_conflict(self):
+        c = _client()
+        with patch.object(_CompatTaigaClient, "_request", return_value=None) as req:
+            c.get("/x", params={"a": "explicit"}, query_params={"a": "stray", "b": 2})
+        assert req.call_args.kwargs["params"] == {"a": "explicit", "b": 2}
+
+
+class TestBuggyTasksMethodsNowWork:
+    """Drive the actual pytaigaclient Tasks methods (the ones that pass
+    query_params=) through the shim and confirm they no longer raise and route
+    params correctly. These are the latent siblings of the get_by_ref bug."""
+
+    def test_get_by_ref(self):
+        c = _client()
+        with patch.object(
+            _CompatTaigaClient, "_request", return_value={"id": 200, "ref": 7}
+        ) as req:
+            result = c.tasks.get_by_ref(ref=7, project=1)
+        assert result == {"id": 200, "ref": 7}
+        assert req.call_args.args == ("GET", "/tasks/by_ref")
+        assert req.call_args.kwargs["params"] == {"ref": 7, "project": 1}
+        assert "query_params" not in req.call_args.kwargs
+
+    def test_list(self):
+        c = _client()
+        with patch.object(_CompatTaigaClient, "_request", return_value=[]) as req:
+            c.tasks.list(query_params={"project": 1, "user_story": 50})
+        assert req.call_args.kwargs["params"] == {"project": 1, "user_story": 50}
+        assert "query_params" not in req.call_args.kwargs
+
+    def test_filters_data(self):
+        c = _client()
+        with patch.object(_CompatTaigaClient, "_request", return_value={}) as req:
+            c.tasks.filters_data(project_id=1)
+        assert "query_params" not in req.call_args.kwargs
+        assert req.call_args.kwargs["params"] == {"project": 1}
+
+    def test_list_attachments(self):
+        c = _client()
+        with patch.object(_CompatTaigaClient, "_request", return_value=[]) as req:
+            c.tasks.list_attachments(project=1, object_id=200)
+        assert "query_params" not in req.call_args.kwargs
+        assert req.call_args.kwargs["params"] == {"project": 1, "object_id": 200}

--- a/uv.lock
+++ b/uv.lock
@@ -712,7 +712,7 @@ cli = [
 
 [[package]]
 name = "mcp-taiga-bridge"
-version = "1.18.0"
+version = "1.20.3"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },


### PR DESCRIPTION
Closes #87.

## Problem

`add_comment(entity_type="task")` fails server-side with:

```
TaigaClient._request() got an unexpected keyword argument 'query_params'
```

The root cause is in the pinned `pytaigaclient`: its `Tasks` resource calls `self.client.get(endpoint, query_params=...)`, but `TaigaClient.get` only accepts `params=` and forwards unknown kwargs into `_request()`, which rejects them. A library-wide audit shows the defect is **isolated to the Tasks resource** — every other resource correctly uses `params=`:

| Tasks method | reached today? |
|---|---|
| `get_by_ref` | yes — broke `add_comment` (this issue) and previously `get_task_by_ref` |
| `list` | latent (listing goes via the wrapper's raw GET, not `tasks.list()`) |
| `filters_data` | latent |
| `list_attachments` | latent |

`get_by_ref` was the only one reached so far; the other three would fail identically the moment a tool calls them. This is a regression that survived #79 (that PR fixed only the `Tasks.edit()` paths).

## Fix

Two layers:

1. **Root-cause backstop** — a `_CompatTaigaClient(TaigaClient)` subclass in `taiga_client.py` whose `get()` remaps a stray `query_params=` kwarg onto `params=`. Every resource routes through this one method, so it neutralizes the entire bug class — current and future — in one place. No-op for correctly-written callers. We can't patch the dependency itself (pinned to an upstream commit of `talhaorak/pyTaigaClient`, and this fork doesn't PR upstream).

2. **Explicit call-site fix** — `add_comment` now resolves the ref via `/{segment}/by_ref` with `params=` directly (mirroring `update_task`/`set_task_status`/`get_task_by_ref`), so the hot path is clear and self-documenting rather than relying on the shim's magic.

## Tests

- `tests/test_server_workflow.py::TestAddComment` — task path resolves via `/tasks/by_ref` with `params=`, PATCHes correctly, and never calls `tasks.get_by_ref` (regression guard); plus story-path, not-found, invalid-type, empty-text.
- `tests/test_taiga_client.py` — drives all four real `Tasks` methods (`get_by_ref`, `list`, `filters_data`, `list_attachments`) through the shim and asserts `params=`/no `query_params`; plus passthrough and explicit-params-win-on-conflict.
- Registered the new test file in the CI job, pre-commit hook, and `run_unit_tests.sh` (they enumerate files explicitly, so a new file would otherwise be skipped).

`./run_unit_tests.sh`: **437 passed**. ruff lint + format clean.

## Scope confirmation

The **full server** (`server_full.py`) needs no separate fix: its `add_comment` takes a numeric `object_id` + direct GET, `get_task_by_ref` already has the direct-endpoint workaround, and its only generic `get_by_ref` helper is called solely for issues/epics (both correct). The shim covers it regardless.

## Deploy note

Bug is live on deployed **v1.20.3** (`main` carries the identical line). Redeploy after merge to restore task comments via MCP.