### PR TITLE
feat: resolve status ids to names on read paths + add get_story/get_task/get_issue (#95)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The bridge ships two servers in a single image. Select one at runtime via the `T
 
 | Mode | Tools | Best for |
 |---|---|---|
-| `workflow` (default) | ~31 intent tools | Product Owners and team members managing projects daily |
+| `workflow` (default) | ~34 intent tools | Product Owners and team members managing projects daily |
 | `full` | 107 CRUD tools | Automation scripts, admin tasks, full API access |
 
 **Workflow mode** (default) accepts human-readable names everywhere — project slug, sprint name, status name, username — and resolves them internally. One call to `get_sprint_board` returns a complete board view with all stories and tasks; `plan_sprint` creates a sprint and assigns stories in a single step.
@@ -51,7 +51,7 @@ TAIGA_SERVER_MODE=full ./run.sh
 
 ## Features
 
-### Workflow mode tools (~31)
+### Workflow mode tools (~34)
 
 Intent-based tools that resolve names and composite API calls:
 
@@ -80,7 +80,8 @@ Intent-based tools that resolve names and composite API calls:
 | `assign_item` | Assign any entity by username |
 | `get_wiki` / `upsert_wiki` | Get or create/update wiki pages |
 | `add_comment` | Comment on any entity by ref |
-| `search` | Full-text search across all entity types |
+| `search` | Full-text search across all entity types (status resolved to name + `is_closed`) |
+| `get_story` / `get_task` / `get_issue` | Read one item by ref — resolved status name, `is_closed`, assignee, etc. (no mutation) |
 | `get_current_user` | Return authenticated user identity — resolves "me" for assign/filter calls |
 | `session_status` | Check whether the current session is authenticated and active |
 
@@ -445,7 +446,7 @@ client.call_tool("logout", {"session_id": session_id})
 ```
 pytaiga-mcp/
 ├── src/
-│   ├── server_workflow.py  # Workflow/intent tools (~31) — default mode
+│   ├── server_workflow.py  # Workflow/intent tools (~34) — default mode
 │   ├── server_full.py      # Full CRUD tools (107) — full mode
 │   ├── taiga_client.py     # Taiga API client wrapper
 │   └── config.py           # Configuration settings with Pydantic

--- a/src/server_workflow.py
+++ b/src/server_workflow.py
@@ -205,6 +205,7 @@ _STATUS_RESOURCE_MAP = {
     "user_story": "userstory_statuses",
     "task": "task_statuses",
     "issue": "issue_statuses",
+    "epic": "epic_statuses",
 }
 
 _ISSUE_ATTR_RESOURCE_MAP = {
@@ -248,6 +249,31 @@ def _resolve_status(
         available = [s["name"] for s in statuses]
         raise ValueError(f"Status '{status_name}' not found. Available: {available}")
     return matches[0]["id"]
+
+
+def _status_map(
+    client: TaigaClientWrapper,
+    project_id: int,
+    entity_type: str,
+    session_id: str,
+) -> Dict[int, Dict[str, Any]]:
+    """Return a {status_id: {"name", "is_closed"}} map for an entity type, cached per session.
+
+    Shares the per-session status cache with `_resolve_status` (same cache key), so a
+    search that resolves statuses and a later name→id resolution reuse one API call.
+    Returns an empty map for entity types that have no status resource.
+    """
+    resource = _STATUS_RESOURCE_MAP.get(entity_type)
+    if not resource:
+        return {}
+    statuses = _cached(
+        session_id,
+        f"statuses_{entity_type}_{project_id}",
+        lambda: client.list_resources(resource, project_id=project_id),
+    )
+    return {
+        s["id"]: {"name": s.get("name"), "is_closed": s.get("is_closed", False)} for s in statuses
+    }
 
 
 def _resolve_user(
@@ -339,6 +365,20 @@ def _resolve_story_refs(client: TaigaClientWrapper, project_id: int, refs: List[
     return [by_ref[r] for r in refs]
 
 
+def _is_closed(item: Dict[str, Any]) -> bool:
+    """Closed-ness of a work item, from the top-level field or its status row.
+
+    Taiga's user-story serializer carries a top-level `is_closed`, but task and
+    issue payloads don't always. `status_extra_info.is_closed` is the same
+    property on the status row itself — the authoritative source `search` uses —
+    so fall back to it when the top-level field is absent.
+    """
+    val = item.get("is_closed")
+    if val is None:
+        val = (item.get("status_extra_info") or {}).get("is_closed", False)
+    return bool(val)
+
+
 def _story_summary(us: Dict[str, Any]) -> Dict[str, Any]:
     """Extract readable fields from a raw user story dict."""
     return {
@@ -347,7 +387,7 @@ def _story_summary(us: Dict[str, Any]) -> Dict[str, Any]:
         "status": (us.get("status_extra_info") or {}).get("name") or us.get("status"),
         "assignee": (us.get("assigned_to_extra_info") or {}).get("full_name_display"),
         "is_blocked": us.get("is_blocked", False),
-        "is_closed": us.get("is_closed", False),
+        "is_closed": _is_closed(us),
         "sprint": (us.get("milestone_extra_info") or {}).get("name"),
         "tags": us.get("tags", []),
     }
@@ -360,6 +400,23 @@ def _task_summary(task: Dict[str, Any]) -> Dict[str, Any]:
         "status": (task.get("status_extra_info") or {}).get("name") or task.get("status"),
         "assignee": (task.get("assigned_to_extra_info") or {}).get("full_name_display"),
         "is_blocked": task.get("is_blocked", False),
+        "is_closed": _is_closed(task),
+    }
+
+
+def _issue_summary(issue: Dict[str, Any]) -> Dict[str, Any]:
+    """Extract readable fields from a raw issue dict (resolved names, not raw ids)."""
+    return {
+        "ref": issue.get("ref"),
+        "subject": issue.get("subject"),
+        "status": (issue.get("status_extra_info") or {}).get("name") or issue.get("status"),
+        "assignee": (issue.get("assigned_to_extra_info") or {}).get("full_name_display"),
+        "priority": (issue.get("priority_extra_info") or {}).get("name"),
+        "severity": (issue.get("severity_extra_info") or {}).get("name"),
+        "type": (issue.get("type_extra_info") or {}).get("name"),
+        "is_blocked": issue.get("is_blocked", False),
+        "is_closed": _is_closed(issue),
+        "tags": issue.get("tags", []),
     }
 
 
@@ -687,19 +744,121 @@ def search(
 
     def do_search():
         proj = _resolve_project(client, project)
-        result = client.api.get("/search", params={"project": proj["id"], "text": query})
+        project_id = proj["id"]
+        result = client.api.get("/search", params={"project": project_id, "text": query})
+
+        # Taiga's /search echoes status as a raw numeric id with no name or
+        # is_closed flag (issue #95). Resolve each entity group's status against
+        # the project's status table so reads are self-interpreting and match the
+        # write tools' flat {status: <name>, is_closed: <bool>} shape.
+        def _resolved(group_key: str, entity_type: str) -> List[Dict[str, Any]]:
+            items = result.get(group_key, []) or []
+            if not items:
+                return []
+            status_by_id = _status_map(client, project_id, entity_type, actual_session_id)
+            for item in items:
+                info = status_by_id.get(item.get("status"))
+                if info is not None:
+                    item["status"] = info["name"]
+                    item["is_closed"] = info["is_closed"]
+            return items
+
         return {
             "query": query,
             "project": proj["slug"],
             "count": result.get("count", 0),
-            "user_stories": result.get("userstories", []),
-            "tasks": result.get("tasks", []),
-            "issues": result.get("issues", []),
-            "epics": result.get("epics", []),
+            "user_stories": _resolved("userstories", "story"),
+            "tasks": _resolved("tasks", "task"),
+            "issues": _resolved("issues", "issue"),
+            "epics": _resolved("epics", "epic"),
             "wiki_pages": result.get("wikipages", []),
         }
 
     return _execute_taiga_operation("search", do_search, f"project={project} query={query!r}")
+
+
+# ---------------------------------------------------------------------------
+# Read-by-ref tools (pure inspection: status, assignee, … resolved to names)
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(
+    "get_story",
+    description=(
+        "Read a single user story by its ref number. Returns resolved human fields "
+        "(status name, is_closed, assignee, sprint, tags) — no mutation. "
+        "project accepts slug or ID."
+    ),
+)
+def get_story(
+    project: Union[str, int],
+    ref: int,
+    session_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    actual_session_id = _get_session_id(session_id)
+    client = _get_authenticated_client(actual_session_id)
+
+    def do_get():
+        proj = _resolve_project(client, project)
+        story = client.api.user_stories.get_by_ref(ref=ref, project=proj["id"])
+        if not story:
+            raise ValueError(f"User story #{ref} not found in project '{proj['slug']}'.")
+        return _story_summary(story)
+
+    return _execute_taiga_operation("get_story", do_get, f"#{ref} in {project}")
+
+
+@mcp.tool(
+    "get_task",
+    description=(
+        "Read a single task by its ref number. Returns resolved human fields "
+        "(status name, is_closed, assignee) — no mutation. project accepts slug or ID."
+    ),
+)
+def get_task(
+    project: Union[str, int],
+    ref: int,
+    session_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    actual_session_id = _get_session_id(session_id)
+    client = _get_authenticated_client(actual_session_id)
+
+    def do_get():
+        proj = _resolve_project(client, project)
+        # pytaigaclient tasks.get_by_ref passes query_params= but TaigaClient.get()
+        # expects params= (issue #87). Bypass via direct API call, as set_task_status does.
+        task = client.api.get("/tasks/by_ref", params={"ref": ref, "project": proj["id"]})
+        if not task:
+            raise ValueError(f"Task #{ref} not found in project '{proj['slug']}'.")
+        return _task_summary(task)
+
+    return _execute_taiga_operation("get_task", do_get, f"task #{ref} in {project}")
+
+
+@mcp.tool(
+    "get_issue",
+    description=(
+        "Read a single issue by its ref number. Returns resolved human fields "
+        "(status name, is_closed, assignee, priority, severity, type, tags) — no mutation. "
+        "project accepts slug or ID."
+    ),
+)
+def get_issue(
+    project: Union[str, int],
+    ref: int,
+    session_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    actual_session_id = _get_session_id(session_id)
+    client = _get_authenticated_client(actual_session_id)
+
+    def do_get():
+        proj = _resolve_project(client, project)
+        issue = client.api.issues.get_by_ref(ref=ref, project=proj["id"])
+        if not issue:
+            raise ValueError(f"Issue #{ref} not found in project '{proj['slug']}'.")
+        return _issue_summary(issue)
+
+    return _execute_taiga_operation("get_issue", do_get, f"#{ref} in {project}")
 
 
 # ---------------------------------------------------------------------------
@@ -1330,6 +1489,7 @@ def update_issue(
             "type": (result.get("type_extra_info") or {}).get("name"),
             "assignee": (result.get("assigned_to_extra_info") or {}).get("full_name_display"),
             "is_blocked": result.get("is_blocked"),
+            "is_closed": result.get("is_closed", False),
         }
 
     return _execute_taiga_operation("update_issue", do_update, f"#{ref} in {project}")

--- a/src/server_workflow.py
+++ b/src/server_workflow.py
@@ -759,10 +759,14 @@ def search(
             for item in items:
                 info = status_by_id.get(item.get("status"))
                 if info is not None:
+                    # Known status: the status table is authoritative.
                     item["status"] = info["name"]
-                # Always surface is_closed so the output shape is uniform; None
-                # only for an unknown id (status left as the raw value, not faked).
-                item["is_closed"] = info["is_closed"] if info is not None else None
+                    item["is_closed"] = info["is_closed"]
+                else:
+                    # Unknown id: keep the raw status and don't clobber any
+                    # is_closed the payload already carries; default to None so
+                    # the key is still present and the output shape stays uniform.
+                    item.setdefault("is_closed", None)
             return items
 
         return {

--- a/src/server_workflow.py
+++ b/src/server_workflow.py
@@ -760,7 +760,9 @@ def search(
                 info = status_by_id.get(item.get("status"))
                 if info is not None:
                     item["status"] = info["name"]
-                    item["is_closed"] = info["is_closed"]
+                # Always surface is_closed so the output shape is uniform; None
+                # only for an unknown id (status left as the raw value, not faked).
+                item["is_closed"] = info["is_closed"] if info is not None else None
             return items
 
         return {

--- a/src/taiga_client.py
+++ b/src/taiga_client.py
@@ -20,6 +20,7 @@ _RESOURCE_ENDPOINTS = {
     "userstory_statuses": "/userstory-statuses",
     "task_statuses": "/task-statuses",
     "issue_statuses": "/issue-statuses",
+    "epic_statuses": "/epic-statuses",
     "issue_types": "/issue-types",
     "priorities": "/priorities",
     "severities": "/severities",

--- a/tests/test_server_workflow.py
+++ b/tests/test_server_workflow.py
@@ -1635,6 +1635,30 @@ class TestSearch:
         assert result["issues"][0]["status"] == 999
         assert result["issues"][0]["is_closed"] is None
 
+    def test_unknown_id_preserves_existing_is_closed(self, session, mock_client):
+        # If the payload already carries is_closed, an unknown status id must not
+        # clobber it — the status table is authoritative only when it has the id.
+        search_result = {
+            "count": 1,
+            "issues": [{"ref": 5, "subject": "Bug", "status": 999, "is_closed": True}],
+            "userstories": [],
+            "tasks": [],
+            "epics": [],
+            "wikipages": [],
+        }
+
+        def api_get(path, params=None):
+            if "/search" in str(path):
+                return search_result
+            return self._project()
+
+        mock_client.api.get.side_effect = api_get
+        mock_client.list_resources.return_value = [{"id": 57, "name": "New", "is_closed": False}]
+
+        result = wf.search("p", "x", session_id=session)
+        assert result["issues"][0]["status"] == 999
+        assert result["issues"][0]["is_closed"] is True
+
     def test_resolves_epic_status(self, session, mock_client):
         search_result = {
             "count": 1,

--- a/tests/test_server_workflow.py
+++ b/tests/test_server_workflow.py
@@ -1630,9 +1630,36 @@ class TestSearch:
         mock_client.list_resources.return_value = [{"id": 57, "name": "New", "is_closed": False}]
 
         result = wf.search("p", "x", session_id=session)
-        # Unknown id is left as-is rather than mislabelled.
+        # Unknown id is left as-is rather than mislabelled, but is_closed is still
+        # present (None) so the output shape stays uniform across items.
         assert result["issues"][0]["status"] == 999
-        assert "is_closed" not in result["issues"][0]
+        assert result["issues"][0]["is_closed"] is None
+
+    def test_resolves_epic_status(self, session, mock_client):
+        search_result = {
+            "count": 1,
+            "issues": [],
+            "userstories": [],
+            "tasks": [],
+            "epics": [{"ref": 42, "subject": "Epic", "status": 30}],
+            "wikipages": [],
+        }
+
+        def api_get(path, params=None):
+            if "/search" in str(path):
+                return search_result
+            return self._project()
+
+        mock_client.api.get.side_effect = api_get
+        mock_client.list_resources.return_value = [
+            {"id": 30, "name": "In progress", "is_closed": False}
+        ]
+
+        result = wf.search("p", "x", session_id=session)
+        assert result["epics"][0]["status"] == "In progress"
+        assert result["epics"][0]["is_closed"] is False
+        # Resolved against the epic_statuses table specifically.
+        mock_client.list_resources.assert_called_once_with("epic_statuses", project_id=1)
 
 
 class TestGetStory:

--- a/tests/test_server_workflow.py
+++ b/tests/test_server_workflow.py
@@ -1544,3 +1544,188 @@ class TestGetCurrentUser:
     def test_unauthenticated_raises(self):
         with pytest.raises((ValueError, PermissionError)):
             wf.get_current_user(session_id="nonexistent")
+
+
+# ---------------------------------------------------------------------------
+# Status-id resolution on reads (#95) — search + get_* by ref
+# ---------------------------------------------------------------------------
+
+
+class TestStatusMap:
+    def test_builds_id_to_name_isclosed_map(self, mock_client):
+        mock_client.list_resources.return_value = [
+            {"id": 57, "name": "New", "is_closed": False},
+            {"id": 60, "name": "Closed", "is_closed": True},
+        ]
+        result = wf._status_map(mock_client, 1, "issue", "sess")
+        assert result == {
+            57: {"name": "New", "is_closed": False},
+            60: {"name": "Closed", "is_closed": True},
+        }
+
+    def test_shares_cache_with_resolve_status(self, mock_client):
+        mock_client.list_resources.return_value = [{"id": 60, "name": "Closed", "is_closed": True}]
+        wf._resolve_status(mock_client, 1, "issue", "Closed", "sess")
+        wf._status_map(mock_client, 1, "issue", "sess")
+        # One fetch shared between resolver and map (same session cache key).
+        mock_client.list_resources.assert_called_once_with("issue_statuses", project_id=1)
+
+    def test_unknown_entity_type_returns_empty(self, mock_client):
+        assert wf._status_map(mock_client, 1, "wiki", "sess") == {}
+        mock_client.list_resources.assert_not_called()
+
+
+class TestSearch:
+    def _project(self):
+        return {"id": 1, "slug": "p", "name": "P"}
+
+    def test_resolves_raw_status_ids_to_name_and_is_closed(self, session, mock_client):
+        search_result = {
+            "count": 2,
+            "issues": [{"ref": 1212, "subject": "Bug", "status": 57}],
+            "userstories": [{"ref": 1114, "subject": "Story", "status": 67}],
+            "tasks": [],
+            "epics": [],
+            "wikipages": [{"id": 9, "title": "Page"}],
+        }
+
+        def api_get(path, params=None):
+            if "/search" in str(path):
+                return search_result
+            return self._project()
+
+        mock_client.api.get.side_effect = api_get
+        # _resolved is called in order story, task, issue, epic; only non-empty
+        # groups fetch a status table → userstory_statuses then issue_statuses.
+        mock_client.list_resources.side_effect = [
+            [{"id": 67, "name": "In progress", "is_closed": False}],  # userstory_statuses
+            [{"id": 57, "name": "New", "is_closed": False}],  # issue_statuses
+        ]
+
+        result = wf.search("p", "anything", session_id=session)
+
+        assert result["issues"][0]["status"] == "New"
+        assert result["issues"][0]["is_closed"] is False
+        assert result["user_stories"][0]["status"] == "In progress"
+        assert result["user_stories"][0]["is_closed"] is False
+        # Empty groups don't trigger a status fetch.
+        assert mock_client.list_resources.call_count == 2
+
+    def test_leaves_status_untouched_when_id_unknown(self, session, mock_client):
+        search_result = {
+            "count": 1,
+            "issues": [{"ref": 5, "subject": "Bug", "status": 999}],
+            "userstories": [],
+            "tasks": [],
+            "epics": [],
+            "wikipages": [],
+        }
+
+        def api_get(path, params=None):
+            if "/search" in str(path):
+                return search_result
+            return self._project()
+
+        mock_client.api.get.side_effect = api_get
+        mock_client.list_resources.return_value = [{"id": 57, "name": "New", "is_closed": False}]
+
+        result = wf.search("p", "x", session_id=session)
+        # Unknown id is left as-is rather than mislabelled.
+        assert result["issues"][0]["status"] == 999
+        assert "is_closed" not in result["issues"][0]
+
+
+class TestGetStory:
+    def test_returns_resolved_summary(self, session, mock_client):
+        mock_client.api.get.return_value = {"id": 1, "slug": "p", "name": "P"}
+        mock_client.api.user_stories.get_by_ref.return_value = {
+            "ref": 3,
+            "subject": "Story A",
+            "status_extra_info": {"name": "In Progress"},
+            "assigned_to_extra_info": {"full_name_display": "Alice"},
+            "is_closed": False,
+        }
+        result = wf.get_story("p", 3, session_id=session)
+        assert result["status"] == "In Progress"
+        assert result["is_closed"] is False
+        assert result["assignee"] == "Alice"
+        mock_client.api.user_stories.get_by_ref.assert_called_once_with(ref=3, project=1)
+
+    def test_raises_when_not_found(self, session, mock_client):
+        mock_client.api.get.return_value = {"id": 1, "slug": "p", "name": "P"}
+        mock_client.api.user_stories.get_by_ref.return_value = None
+        with pytest.raises(ValueError, match="not found"):
+            wf.get_story("p", 99, session_id=session)
+
+
+class TestGetTask:
+    def test_uses_by_ref_endpoint_not_helper(self, session, mock_client):
+        project = {"id": 1, "slug": "p", "name": "P"}
+        task = {
+            "ref": 7,
+            "subject": "Task 1",
+            "status_extra_info": {"name": "Done"},
+            "is_closed": True,
+        }
+
+        def api_get(path, params=None):
+            if "/tasks/by_ref" in str(path):
+                return task
+            return project
+
+        mock_client.api.get.side_effect = api_get
+        result = wf.get_task("p", 7, session_id=session)
+        assert result["status"] == "Done"
+        assert result["is_closed"] is True
+        # Must NOT route through the buggy tasks.get_by_ref helper.
+        mock_client.api.tasks.get_by_ref.assert_not_called()
+
+    def test_raises_when_not_found(self, session, mock_client):
+        def api_get(path, params=None):
+            if "/tasks/by_ref" in str(path):
+                return None
+            return {"id": 1, "slug": "p", "name": "P"}
+
+        mock_client.api.get.side_effect = api_get
+        with pytest.raises(ValueError, match="not found"):
+            wf.get_task("p", 99, session_id=session)
+
+
+class TestGetIssue:
+    def test_returns_resolved_summary(self, session, mock_client):
+        mock_client.api.get.return_value = {"id": 1, "slug": "p", "name": "P"}
+        mock_client.api.issues.get_by_ref.return_value = {
+            "ref": 1212,
+            "subject": "Bug",
+            "status_extra_info": {"name": "New"},
+            "priority_extra_info": {"name": "High"},
+            "severity_extra_info": {"name": "Normal"},
+            "type_extra_info": {"name": "Bug"},
+            "assigned_to_extra_info": None,
+            "is_closed": False,
+        }
+        result = wf.get_issue("p", 1212, session_id=session)
+        assert result["status"] == "New"
+        assert result["is_closed"] is False
+        assert result["priority"] == "High"
+        assert result["type"] == "Bug"
+        mock_client.api.issues.get_by_ref.assert_called_once_with(ref=1212, project=1)
+
+    def test_raises_when_not_found(self, session, mock_client):
+        mock_client.api.get.return_value = {"id": 1, "slug": "p", "name": "P"}
+        mock_client.api.issues.get_by_ref.return_value = None
+        with pytest.raises(ValueError, match="not found"):
+            wf.get_issue("p", 99, session_id=session)
+
+    def test_is_closed_falls_back_to_status_extra_info(self, session, mock_client):
+        # Payload with no top-level is_closed — closed-ness must be read off the
+        # status row so the triage signal ("is it closed?") isn't silently False.
+        mock_client.api.get.return_value = {"id": 1, "slug": "p", "name": "P"}
+        mock_client.api.issues.get_by_ref.return_value = {
+            "ref": 60,
+            "subject": "Done bug",
+            "status_extra_info": {"name": "Closed", "is_closed": True},
+        }
+        result = wf.get_issue("p", 60, session_id=session)
+        assert result["status"] == "Closed"
+        assert result["is_closed"] is True


### PR DESCRIPTION
Closes #95.

## Problem

Taiga's `/search` echoed `status` as a **raw numeric id** with no name and no `is_closed` flag, and workflow mode had no pure read-by-ref tool. The inspect-then-decide intent ("is #1212 closed?") therefore had no non-destructive path — you either mutated the item or triangulated against a known-status sibling.

## Changes

- **`search` resolves status** — each entity group's raw `status` id is mapped against the project's status table → flat `status: <name>` + `is_closed: <bool>`. Status tables are fetched lazily per non-empty group and cached per session (shares `_resolve_status`'s cache key, so no extra API calls).
- **New `get_story` / `get_task` / `get_issue`** — read one item by ref, returning resolved human fields (status name, `is_closed`, assignee; plus priority/severity/type/tags for issues). `get_task` uses the `/tasks/by_ref` direct endpoint to dodge the pytaigaclient `query_params` bug (#87).
- **Uniform `is_closed` source** — new `_is_closed()` helper reads the top-level field, falling back to `status_extra_info.is_closed` (task/issue payloads don't reliably carry it top-level — confirmed against `RESPONSE_FIELDS` in the full server). Matches the source `search` uses. Also surfaced on `update_issue`'s return.
- Registered the `/epic-statuses` endpoint so epic search hits resolve too.

## Shape decision (proposed #1 vs implemented)

The issue proposed nested `{id, name, is_closed}`. I implemented **flat `status` name + `is_closed`** instead, to match the existing write tools (`set_story_status`, `set_task_status`, `update_issue`) — that is true read↔write symmetry, and the raw id was the thing being complained about, not something callers read back. Easy to revert to nested if there's a round-trip reason I can't see.

Fixes #95 items 1 (search) and 2 (get_* read tools). Item 3 (`list_issue_statuses`) was marked optional and is made redundant by 1+2, so it's deliberately skipped to keep the workflow surface lean.

## Tests

- 452 unit tests pass (was 451). New: `TestStatusMap`, `TestSearch`, `TestGetStory`, `TestGetTask`, `TestGetIssue` — including the `status_extra_info` fallback path and the empty-group / unknown-id edges.
- New tools pass `test_tool_params_have_typed_schemas` (no bare `Any` params).
- ruff lint + format clean.
- README workflow tool count bumped (~31 → ~34). CHANGELOG left to semantic-release (the `feat:` subject yields a minor bump).