### PR TITLE
fix: correct create_story epic-link payload field names

### DIFF
--- a/src/server_workflow.py
+++ b/src/server_workflow.py
@@ -961,7 +961,7 @@ def create_story(
                 raise ValueError(f"Epic #{epic} not found — story was created but not linked.")
             client.api.post(
                 f"/epics/{epic_data['id']}/related_userstories",
-                json={"project_id": project_id, "user_story_id": result["id"]},
+                json={"epic": epic_data["id"], "user_story": result["id"]},
             )
 
         return {

--- a/src/server_workflow.py
+++ b/src/server_workflow.py
@@ -941,6 +941,15 @@ def create_story(
         proj = _resolve_project(client, project)
         project_id = proj["id"]
 
+        # Validate the epic BEFORE creating the story. Create and epic-link are two
+        # separate Taiga calls, so resolving the epic first means a bad ref fails
+        # cleanly instead of leaving an orphaned (created-but-unlinked) story behind.
+        epic_data = None
+        if epic is not None:
+            epic_data = client.api.get("/epics/by_ref", params={"ref": epic, "project": project_id})
+            if not epic_data:
+                raise ValueError(f"Epic #{epic} not found in project '{proj['slug']}'.")
+
         payload: Dict[str, Any] = {"project": project_id, "subject": subject}
         if description:
             payload["description"] = description
@@ -954,11 +963,8 @@ def create_story(
 
         result = client.api.user_stories.create(**payload)
 
-        # Link to epic after creation
-        if epic is not None and result:
-            epic_data = client.api.get("/epics/by_ref", params={"ref": epic, "project": project_id})
-            if not epic_data:
-                raise ValueError(f"Epic #{epic} not found — story was created but not linked.")
+        # Link to the already-validated epic.
+        if epic_data is not None and result:
             client.api.post(
                 f"/epics/{epic_data['id']}/related_userstories",
                 json={"epic": epic_data["id"], "user_story": result["id"]},

--- a/tests/test_server_workflow.py
+++ b/tests/test_server_workflow.py
@@ -405,6 +405,18 @@ class TestCreateStory:
             json={"epic": 99, "user_story": 100},
         )
 
+    def test_epic_not_found_creates_no_story(self, session, mock_client):
+        # Epic is validated before creation, so a bad ref must NOT leave an
+        # orphaned (created-but-unlinked) story behind.
+        mock_client.api.get.side_effect = [
+            {"id": 1, "slug": "test", "name": "Test"},
+            None,  # /epics/by_ref → not found
+        ]
+        with pytest.raises(ValueError, match="Epic #7 not found"):
+            wf.create_story("test", "Story", epic=7, session_id=session)
+        mock_client.api.user_stories.create.assert_not_called()
+        mock_client.api.post.assert_not_called()
+
 
 class TestSetStoryStatus:
     def test_resolves_status_and_updates(self, session, mock_client):

--- a/tests/test_server_workflow.py
+++ b/tests/test_server_workflow.py
@@ -383,6 +383,28 @@ class TestCreateStory:
         call_kwargs = mock_client.api.user_stories.create.call_args.kwargs
         assert call_kwargs["assigned_to"] == 7
 
+    def test_creates_story_with_epic_link(self, session, mock_client):
+        # api.get: 1st resolves the project (by_slug), 2nd resolves the epic (by_ref).
+        mock_client.api.get.side_effect = [
+            {"id": 1, "slug": "test", "name": "Test"},
+            {"id": 99, "ref": 7, "subject": "Epic"},
+        ]
+        mock_client.api.user_stories.create.return_value = {
+            "id": 100,
+            "ref": 5,
+            "subject": "Story",
+            "milestone_extra_info": None,
+        }
+        result = wf.create_story("test", "Story", epic=7, session_id=session)
+        assert result["status"] == "created"
+        assert result["epic_linked"] is True
+        # Taiga's related_userstories endpoint requires 'epic' + 'user_story'
+        # (not project_id/user_story_id) — same payload as update_story relink.
+        mock_client.api.post.assert_called_once_with(
+            "/epics/99/related_userstories",
+            json={"epic": 99, "user_story": 100},
+        )
+
 
 class TestSetStoryStatus:
     def test_resolves_status_and_updates(self, session, mock_client):


### PR DESCRIPTION
## Problem

`create_story(epic=…)` failed to link the story to the epic. The epic-link POST returned a 400 (surfaced as a tool error), **but the story had already been created** — leaving it orphaned (created, not linked):

```
API Error 400: user_story: This field is required. | epic: This field is required.
```

`create_story` POSTed `{project_id, user_story_id}` to `/epics/{id}/related_userstories`, but Taiga's endpoint requires the fields **`epic`** and **`user_story`** (both required).

## Root cause

`create_story` was the lone outlier. The two sibling code paths already used the correct field names:

| Location | Function | Payload |
|---|---|---|
| `server_full.py` | `link_user_story_to_epic` | `{"epic", "user_story"}` ✅ |
| `server_workflow.py` | `update_story` (relink) | `{"epic", "user_story"}` ✅ |
| `server_workflow.py` | **`create_story`** | `{"project_id", "user_story_id"}` ❌ |

It shipped because there was **no test** exercising `create_story(epic=…)`.

## Fix

1. **Payload** — corrected to `{"epic": epic_data["id"], "user_story": result["id"]}`.
2. **Atomicity** — resolve/validate the epic **before** `user_stories.create()`. Create and epic-link are two separate Taiga calls, so a bad epic ref now fails cleanly instead of leaving an orphaned story behind (mirrors `update_story`'s validate-before-mutate pattern). This also makes the response's `epic_linked` truthful — reaching the return now implies the link actually succeeded.

## Tests

- `test_creates_story_with_epic_link` — asserts the correct `{epic, user_story}` payload (mirrors the `update_story` relink tests).
- `test_epic_not_found_creates_no_story` — asserts an unknown epic raises `ValueError` and **no story is created** (no orphan).

## Verification

- 437/437 unit tests pass; ruff lint + format clean; pre-commit hooks pass.

Found in production: `create_story(epic=2)` 400'd, story created but unlinked.