### PR TITLE
ci: auto-merge Dependabot PRs (non-major, checks-gated)

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,32 @@
+# Auto-enable auto-merge on Dependabot PRs.
+#
+# Safe-by-design: this only *enables* GitHub auto-merge, which still waits for
+# all required status checks (lint/test/secrets/docker) to pass before merging.
+# A failing check => the PR stays queued and never merges.
+#
+# Major version bumps are intentionally NOT auto-merged — they wait for a human
+# (e.g. eslint 9->10, typescript 5->6), matching our "review majors" policy.
+name: Dependabot auto-merge
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge (non-major only)
+        if: steps.meta.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --squash "${{ github.event.pull_request.html_url }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds a Dependabot auto-merge workflow.

- Enables GitHub auto-merge on Dependabot PRs so patch/minor bumps self-drain.
- **Required checks still gate** the merge — a failing check keeps the PR queued, never merged.
- **Major** bumps are NOT auto-merged (left for human review).
