### PR TITLE
fix(ci): publish version + stable image tags on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
+      packages: write
 
     steps:
       - uses: actions/checkout@v7
@@ -139,7 +140,44 @@ jobs:
       - name: Python Semantic Release
         id: semrel
         run: |
+          before=$(git describe --tags --abbrev=0 2>/dev/null || echo none)
           uv run semantic-release version --skip-build
           uv run semantic-release publish
+          after=$(git describe --tags --abbrev=0 2>/dev/null || echo none)
+          if [ "$before" != "$after" ]; then
+            echo "released=true"     >> "$GITHUB_OUTPUT"
+            echo "version=${after#v}" >> "$GITHUB_OUTPUT"
+          else
+            echo "released=false"    >> "$GITHUB_OUTPUT"
+          fi
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
+      - name: Normalize image name
+        if: steps.semrel.outputs.released == 'true'
+        id: img
+        run: echo "image=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        if: steps.semrel.outputs.released == 'true'
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        if: steps.semrel.outputs.released == 'true'
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push version + stable
+        if: steps.semrel.outputs.released == 'true'
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ steps.img.outputs.image }}:${{ steps.semrel.outputs.version }}
+            ${{ steps.img.outputs.image }}:stable
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Rollout of the verified litellm pilot. Builds+pushes `ghcr:X.Y.Z` and `ghcr:stable` when a release is cut (gated; `:latest` unchanged).