### PR TITLE
ci: split Dependabot commit prefix (runtime=fix, dev=chore)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,12 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
+    commit-message:
+      # Runtime deps -> fix(deps) so a security/runtime bump cuts a patch release
+      # (-> release-image.yml builds a fresh :stable + :X.Y.Z with the fix).
+      # Dev/tooling deps -> chore(deps-dev): no release.
+      prefix: "fix"
+      prefix-development: "chore"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Runtime dep bumps -> `fix(deps)` (cut a patch -> new :stable image carrying the fix); dev deps -> `chore(deps-dev)` (no release). Matches the langfuse pilot.