### PR TITLE
fix(resolve): tolerate null member/name fields; share resolver across both server flavors (#120)

### DIFF
--- a/src/server_full.py
+++ b/src/server_full.py
@@ -12,7 +12,7 @@ from mcp.server.fastmcp import FastMCP
 from pytaigaclient.exceptions import TaigaAPIError, TaigaException
 
 from src.config import settings
-from src.taiga_client import TaigaClientWrapper
+from src.taiga_client import TaigaClientWrapper, resolve_user_id
 
 # --- Logging Setup ---
 logging.basicConfig(
@@ -1303,15 +1303,36 @@ def delete_user_story(user_story_id: int, session_id: Optional[str] = None) -> D
     return _execute_taiga_operation("delete_user_story", do_delete, f"user story {user_story_id}")
 
 
+def _resolve_assignee_id(
+    user: Union[int, str], resource_type: str, entity_id: int, session_id: str
+) -> int:
+    """Resolve ``user`` to a Taiga user ID for the assign_* tools.
+
+    Ints pass through unchanged (backward-compatible with the historical
+    ``user_id: int`` API — no extra API calls). Strings are treated as a
+    username / email / full name and resolved against the members of the
+    entity's project (looked up from the entity), reusing the shared None-safe
+    ``resolve_user_id`` so full mode gets the same robust resolution as
+    workflow mode (pytaiga-mcp#120).
+    """
+    if isinstance(user, int) and not isinstance(user, bool):
+        return user
+    client = _get_authenticated_client(session_id)
+    entity = client.get_resource(resource_type, entity_id)
+    members = client.list_resources("memberships", project_id=entity.get("project"))
+    return resolve_user_id(members, user)
+
+
 @mcp.tool(
     "assign_user_story_to_user",
-    description="Assigns a specific user story to a specific user. Uses default session if session_id not provided.",
+    description="Assigns a specific user story to a user. `user` accepts a numeric user ID or a username/email/full name (resolved against the project's members). Uses default session if session_id not provided.",
 )
 def assign_user_story_to_user(
-    user_story_id: int, user_id: int, session_id: Optional[str] = None
+    user_story_id: int, user: Union[int, str], session_id: Optional[str] = None
 ) -> Dict[str, Any]:
-    """Assigns a user story to a user."""
+    """Assigns a user story to a user (by ID or username/email/full name)."""
     actual_session_id = _get_session_id(session_id)
+    user_id = _resolve_assignee_id(user, "user_stories", user_story_id, actual_session_id)
     logger.info(
         f"Executing assign_user_story_to_user: US {user_story_id} -> User {user_id}, session {actual_session_id[:8]}..."
     )
@@ -1544,13 +1565,14 @@ def delete_task(task_id: int, session_id: Optional[str] = None) -> Dict[str, Any
 
 @mcp.tool(
     "assign_task_to_user",
-    description="Assigns a specific task to a specific user. Uses default session if session_id not provided.",
+    description="Assigns a specific task to a user. `user` accepts a numeric user ID or a username/email/full name (resolved against the project's members). Uses default session if session_id not provided.",
 )
 def assign_task_to_user(
-    task_id: int, user_id: int, session_id: Optional[str] = None
+    task_id: int, user: Union[int, str], session_id: Optional[str] = None
 ) -> Dict[str, Any]:
-    """Assigns a task to a user."""
+    """Assigns a task to a user (by ID or username/email/full name)."""
     actual_session_id = _get_session_id(session_id)
+    user_id = _resolve_assignee_id(user, "tasks", task_id, actual_session_id)
     logger.info(
         f"Executing assign_task_to_user: Task {task_id} -> User {user_id}, session {actual_session_id[:8]}..."
     )
@@ -1776,13 +1798,14 @@ def delete_issue(issue_id: int, session_id: Optional[str] = None) -> Dict[str, A
 
 @mcp.tool(
     "assign_issue_to_user",
-    description="Assigns a specific issue to a specific user. Uses default session if session_id not provided.",
+    description="Assigns a specific issue to a user. `user` accepts a numeric user ID or a username/email/full name (resolved against the project's members). Uses default session if session_id not provided.",
 )
 def assign_issue_to_user(
-    issue_id: int, user_id: int, session_id: Optional[str] = None
+    issue_id: int, user: Union[int, str], session_id: Optional[str] = None
 ) -> Dict[str, Any]:
-    """Assigns an issue to a user."""
+    """Assigns an issue to a user (by ID or username/email/full name)."""
     actual_session_id = _get_session_id(session_id)
+    user_id = _resolve_assignee_id(user, "issues", issue_id, actual_session_id)
     logger.info(
         f"Executing assign_issue_to_user: Issue {issue_id} -> User {user_id}, session {actual_session_id[:8]}..."
     )
@@ -2833,13 +2856,14 @@ def delete_epic(epic_id: int, session_id: Optional[str] = None) -> Dict[str, Any
 
 @mcp.tool(
     "assign_epic_to_user",
-    description="Assigns a specific epic to a specific user. Uses default session if session_id not provided.",
+    description="Assigns a specific epic to a user. `user` accepts a numeric user ID or a username/email/full name (resolved against the project's members). Uses default session if session_id not provided.",
 )
 def assign_epic_to_user(
-    epic_id: int, user_id: int, session_id: Optional[str] = None
+    epic_id: int, user: Union[int, str], session_id: Optional[str] = None
 ) -> Dict[str, Any]:
-    """Assigns an epic to a user."""
+    """Assigns an epic to a user (by ID or username/email/full name)."""
     actual_session_id = _get_session_id(session_id)
+    user_id = _resolve_assignee_id(user, "epics", epic_id, actual_session_id)
     logger.info(
         f"Executing assign_epic_to_user: Epic {epic_id} -> User {user_id}, session {actual_session_id[:8]}..."
     )

--- a/src/server_workflow.py
+++ b/src/server_workflow.py
@@ -23,7 +23,7 @@ from mcp.server.fastmcp import FastMCP
 from pytaigaclient.exceptions import TaigaAPIError, TaigaException
 
 from src.config import settings
-from src.taiga_client import TaigaClientWrapper
+from src.taiga_client import TaigaClientWrapper, resolve_user_id, safe_lower
 
 # ---------------------------------------------------------------------------
 # Logging
@@ -244,7 +244,7 @@ def _resolve_status(
         f"statuses_{entity_type}_{project_id}",
         lambda: client.list_resources(resource, project_id=project_id),
     )
-    matches = [s for s in statuses if s["name"].lower() == status_name.lower()]
+    matches = [s for s in statuses if safe_lower(s.get("name")) == safe_lower(status_name)]
     if not matches:
         available = [s["name"] for s in statuses]
         raise ValueError(f"Status '{status_name}' not found. Available: {available}")
@@ -288,18 +288,7 @@ def _resolve_user(
         f"members_{project_id}",
         lambda: client.list_resources("memberships", project_id=project_id),
     )
-    needle = username.lower()
-    for m in members:
-        info = m.get("user_extra_info") or {}
-        if (
-            info.get("username", "").lower() == needle
-            or m.get("email", "").lower() == needle
-            or m.get("full_name", "").lower() == needle
-            or info.get("full_name_display", "").lower() == needle
-        ):
-            return m["user"]
-    available = [m.get("full_name") or m.get("email", "?") for m in members]
-    raise ValueError(f"User '{username}' not found in project. Members: {available}")
+    return resolve_user_id(members, username)
 
 
 def _resolve_issue_defaults(
@@ -340,7 +329,7 @@ def _resolve_issue_attribute(
         f"{resource}_{project_id}",
         lambda: client.list_resources(resource, project_id=project_id),
     )
-    matches = [i for i in items if i["name"].lower() == name.lower()]
+    matches = [i for i in items if safe_lower(i.get("name")) == safe_lower(name)]
     if not matches:
         available = [i["name"] for i in items]
         raise ValueError(f"{attr_type.capitalize()} '{name}' not found. Available: {available}")

--- a/src/taiga_client.py
+++ b/src/taiga_client.py
@@ -31,6 +31,51 @@ _RESOURCE_ENDPOINTS = {
 _NO_PAGINATION_HEADERS = {"x-disable-pagination": "True"}
 
 
+def safe_lower(value: Any) -> str:
+    """Lowercase a value, tolerating None.
+
+    Taiga returns JSON ``null`` for unset string fields (e.g. a membership's
+    ``email``/``full_name`` on a pending invitation, or a resource ``name``).
+    A bare ``value.lower()`` on those raised ``'NoneType' object has no
+    attribute 'lower'`` (pytaiga-mcp#120). Coercing ``None`` -> ``""`` first
+    keeps name/username matching robust across both server flavors.
+    """
+    return (value or "").lower()
+
+
+def resolve_user_id(members: List[Dict[str, Any]], identifier: "int | str") -> int:
+    """Resolve a user identifier to a Taiga user ID against a project's memberships.
+
+    ``identifier`` may be an ``int`` (returned unchanged — treated as a user ID)
+    or a string matched case-insensitively against each member's username, email,
+    full name, or display name. Matching is None-safe (see ``safe_lower``): a
+    single member with a null field no longer aborts resolution before the
+    intended user is reached.
+
+    Raises ``ValueError`` if the identifier is empty or not found.
+    """
+    if isinstance(identifier, bool):  # bool is an int subclass — reject to avoid surprises
+        raise ValueError("User identifier must be an int user ID or a name/email string.")
+    if isinstance(identifier, int):
+        return identifier
+    needle = safe_lower(identifier)
+    if not needle:
+        raise ValueError("Empty username/identifier for user resolution.")
+    for m in members:
+        info = m.get("user_extra_info") or {}
+        if needle in (
+            safe_lower(info.get("username")),
+            safe_lower(m.get("email")),
+            safe_lower(m.get("full_name")),
+            safe_lower(info.get("full_name_display")),
+        ):
+            uid = m.get("user")
+            if uid is not None:
+                return uid
+    available = [m.get("full_name") or m.get("email") or "?" for m in members]
+    raise ValueError(f"User '{identifier}' not found in project. Members: {available}")
+
+
 class _CompatTaigaClient(TaigaClient):
     """TaigaClient with a compatibility shim for pytaigaclient's `query_params` bug.
 
@@ -116,6 +161,20 @@ class TaigaClientWrapper:
         if not self.is_authenticated:
             logger.error("Action required authentication, but client is not logged in.")
             raise PermissionError("Client not authenticated. Please login first.")
+
+    def get_resource(self, resource_type: str, resource_id: int) -> Dict[str, Any]:
+        """Fetch a single resource by ID via the raw API.
+
+        Used by name-based assignee resolution to look up an entity's
+        ``project`` before matching a username against that project's members.
+        """
+        self._ensure_authenticated()
+        endpoint = _RESOURCE_ENDPOINTS.get(resource_type)
+        if endpoint is None:
+            raise ValueError(
+                f"Unknown resource type: {resource_type}. Valid: {sorted(_RESOURCE_ENDPOINTS)}"
+            )
+        return self.api.get(f"{endpoint}/{resource_id}")
 
     def list_resources(
         self, resource_type: str, project_id: Optional[int] = None, **filters

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -722,6 +722,36 @@ class TestTaigaTools:
             user_story_id=456, version=1, assigned_to=10
         )
 
+    def test_assign_user_story_to_user_by_username(self, session_setup):
+        """assign_*_to_user resolves a username to an ID via the entity's project members."""
+        session_id, mock_client = session_setup
+        mock_client.get_resource.return_value = {"id": 456, "project": 1}
+        mock_client.list_resources.return_value = [
+            # pending-invite member with null fields first — must not crash (pytaiga-mcp#120)
+            {"user": None, "email": None, "full_name": None, "user_extra_info": None},
+            {
+                "user": 10,
+                "email": "bob@example.com",
+                "full_name": "Bob Stone",
+                "user_extra_info": {"username": "bob", "full_name_display": "Bob Stone"},
+            },
+        ]
+        mock_client.api.user_stories.get.return_value = {
+            "id": 456,
+            "assigned_to": None,
+            "version": 1,
+        }
+        mock_client.api.user_stories.edit.return_value = {
+            "id": 456,
+            "assigned_to": 10,
+            "version": 2,
+        }
+        src_server.assign_user_story_to_user(456, "bob", session_id)
+        mock_client.get_resource.assert_called_once_with("user_stories", 456)
+        mock_client.api.user_stories.edit.assert_called_once_with(
+            user_story_id=456, version=1, assigned_to=10
+        )
+
     def test_unassign_user_story_from_user(self, session_setup):
         """Test unassign_user_story_from_user sets assigned_to to None."""
         session_id, mock_client = session_setup

--- a/tests/test_server_workflow.py
+++ b/tests/test_server_workflow.py
@@ -334,6 +334,21 @@ class TestResolveUser:
         with pytest.raises(ValueError, match="not found"):
             wf._resolve_user(mock_client, 1, "bob", "sess")
 
+    def test_resolves_past_member_with_null_fields(self, mock_client):
+        # Regression for pytaiga-mcp#120: a pending-invite membership with null
+        # email/full_name/user_extra_info must not abort resolution before the
+        # valid member is reached (previously raised 'NoneType' ... 'lower').
+        members = [
+            {"user": None, "email": None, "full_name": None, "user_extra_info": None},
+            *self._members(),
+        ]
+        mock_client.list_resources.return_value = members
+        assert wf._resolve_user(mock_client, 1, "alice", "sess") == 42
+
+    def test_int_identifier_passthrough(self, mock_client):
+        mock_client.list_resources.return_value = self._members()
+        assert wf._resolve_user(mock_client, 1, 99, "sess") == 99
+
 
 # ---------------------------------------------------------------------------
 # Tool smoke tests

--- a/tests/test_taiga_client.py
+++ b/tests/test_taiga_client.py
@@ -5,7 +5,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 from pytaigaclient.exceptions import TaigaException
 
-from src.taiga_client import TaigaClientWrapper, _CompatTaigaClient
+from src.taiga_client import (
+    TaigaClientWrapper,
+    _CompatTaigaClient,
+    resolve_user_id,
+    safe_lower,
+)
 
 
 def _client():
@@ -117,3 +122,92 @@ class TestTaigaClientWrapperLogin:
             with pytest.raises(TaigaException, match="Unexpected login error"):
                 wrapper.login(username="u", password="p")
         assert wrapper.api is None
+
+
+class TestSafeLower:
+    """None-safe lowercasing (pytaiga-mcp#120)."""
+
+    def test_none_becomes_empty_string(self):
+        assert safe_lower(None) == ""
+
+    def test_lowercases_string(self):
+        assert safe_lower("Alice@Example.COM") == "alice@example.com"
+
+    def test_empty_string_stays_empty(self):
+        assert safe_lower("") == ""
+
+
+class TestResolveUserId:
+    """Shared None-safe user resolver used by both server flavors (pytaiga-mcp#120)."""
+
+    def _members(self):
+        return [
+            # pending-invite membership with null fields — must not abort matching
+            {"user": None, "email": None, "full_name": None, "user_extra_info": None},
+            {
+                "user": 42,
+                "email": "alice@example.com",
+                "full_name": "Alice Martin",
+                "user_extra_info": {"username": "alice", "full_name_display": "Alice Martin"},
+            },
+        ]
+
+    def test_int_passes_through_without_lookup(self):
+        # No members needed — an int is a user ID and is returned unchanged.
+        assert resolve_user_id([], 42) == 42
+
+    def test_bool_is_rejected(self):
+        with pytest.raises(ValueError, match="int user ID or a name/email"):
+            resolve_user_id(self._members(), True)
+
+    def test_empty_identifier_rejected(self):
+        with pytest.raises(ValueError, match="Empty username"):
+            resolve_user_id(self._members(), "")
+
+    def test_resolves_by_username_case_insensitive(self):
+        assert resolve_user_id(self._members(), "ALICE") == 42
+
+    def test_resolves_by_email(self):
+        assert resolve_user_id(self._members(), "alice@example.com") == 42
+
+    def test_resolves_by_full_name(self):
+        assert resolve_user_id(self._members(), "Alice Martin") == 42
+
+    def test_resolves_by_display_name(self):
+        assert resolve_user_id(self._members(), "alice martin") == 42
+
+    def test_null_field_member_does_not_crash(self):
+        # The regression: the leading null-field member previously raised
+        # "'NoneType' object has no attribute 'lower'" before reaching Alice.
+        assert resolve_user_id(self._members(), "alice") == 42
+
+    def test_skips_match_when_member_user_is_none(self):
+        # A member matching by email but with user=None must not return None;
+        # resolution continues / raises not-found rather than yielding a null ID.
+        members = [{"user": None, "email": "ghost@example.com", "full_name": None}]
+        with pytest.raises(ValueError, match="not found"):
+            resolve_user_id(members, "ghost@example.com")
+
+    def test_raises_when_not_found(self):
+        with pytest.raises(ValueError, match="not found"):
+            resolve_user_id(self._members(), "bob")
+
+
+class TestGetResource:
+    """get_resource fetches a single entity by ID (used for name-based assignment)."""
+
+    def test_fetches_single_resource_by_id(self):
+        wrapper = TaigaClientWrapper(host="https://taiga.example")
+        wrapper.api = MagicMock()
+        wrapper.api.auth_token = "tok"
+        wrapper.api.get.return_value = {"id": 5, "project": 1}
+        result = wrapper.get_resource("user_stories", 5)
+        assert result == {"id": 5, "project": 1}
+        wrapper.api.get.assert_called_once_with("/userstories/5")
+
+    def test_rejects_unknown_resource_type(self):
+        wrapper = TaigaClientWrapper(host="https://taiga.example")
+        wrapper.api = MagicMock()
+        wrapper.api.auth_token = "tok"
+        with pytest.raises(ValueError, match="Unknown resource type"):
+            wrapper.get_resource("bogus", 5)


### PR DESCRIPTION
Fixes #120.

## Problem

`_resolve_user()` (workflow mode) matched project members with `dict.get(key, "").lower()`. `dict.get(key, "")` only substitutes the default when the key is **absent** — a JSON-`null` value returns `None`, and `None.lower()` raises `'NoneType' object has no attribute 'lower'`. Taiga returns null `email`/`full_name`/`user_extra_info` for members such as pending invitations, so the resolver crashed on that member **before** reaching the requested user — making *every* assignee resolution fail whenever a project had one null-field member. It backed 10 workflow call sites (`assign_item`, `create_story`, all `update_*`/`move_to_sprint`).

## Both flavors benefit

- **Workflow mode** — the actual bug. Fixed, and the two sibling resolvers with the same `["name"].lower()` crash class (`_resolve_status`, `_resolve_issue_attribute`) are hardened too.
- **Full mode** — previously had *no* username resolution (its `assign_*_to_user` tools took a raw `user_id: int`), so it couldn't benefit from a workflow-only patch. It now shares the fixed resolver: `assign_user_story|task|issue|epic_to_user` accept `user: int | str` — a username/email/full name is resolved against the entity's project members. **Ints pass through unchanged → fully backward compatible.**

## Changes

- **`src/taiga_client.py`** — shared, None-safe helpers used by both servers:
  - `safe_lower(value)` → `(value or "").lower()`
  - `resolve_user_id(members, identifier)` → int passthrough; case-insensitive match on username/email/full_name/display; skips members with no `user`; raises `ValueError` on empty/not-found.
  - `TaigaClientWrapper.get_resource(resource_type, id)` → fetch a single entity (to read its `project` for member lookup).
- **`src/server_workflow.py`** — `_resolve_user` delegates to `resolve_user_id`; `_resolve_status` / `_resolve_issue_attribute` use `safe_lower`.
- **`src/server_full.py`** — `_resolve_assignee_id()` helper; the four `assign_*_to_user` tools accept `user: int | str` and resolve via the shared helper.

## Tests

- Workflow: regression test with a null-field member placed **before** the valid one (reproduces #120), plus int-passthrough.
- Full: username-based assignment resolves via `get_resource` + members (with a null-field member first).
- Full suite: **518 passed**; `ruff check` + `ruff format --check` clean; pre-commit hooks pass.

## Notes

- Backward compatible: existing `assign_*_to_user(entity_id, <int>, ...)` callers are unaffected (int short-circuits before any extra API call).
- Out of scope (possible follow-up): resolving `assigned_to` **by name inside the `create_*`/`update_*` kwargs-JSON** tools. This PR covers the direct `assign_*_to_user` surface, which matches the issue.
