### PR TITLE
fix(assign_item): route edit per resource so issues & tasks assign (#123)

### DIFF
--- a/src/server_workflow.py
+++ b/src/server_workflow.py
@@ -2003,7 +2003,15 @@ def assign_item(
         if not current:
             raise ValueError(f"{entity_type.capitalize()} #{ref} not found in '{proj['slug']}'.")
 
-        result = collection.edit(current["id"], assigned_to=user_id, version=current["version"])
+        # pytaigaclient's edit() signatures diverge: Tasks/Issues take a
+        # data={...} dict, while UserStories/Epics take **kwargs. Route
+        # accordingly — matching the update_* tools (pytaiga-mcp#123).
+        if collection_name in ("tasks", "issues"):
+            result = collection.edit(
+                current["id"], version=current["version"], data={"assigned_to": user_id}
+            )
+        else:
+            result = collection.edit(current["id"], version=current["version"], assigned_to=user_id)
         return {
             "ref": ref,
             "entity_type": entity_type,

--- a/tests/test_server_workflow.py
+++ b/tests/test_server_workflow.py
@@ -1995,7 +1995,46 @@ class TestAssignItem:
         }
         result = wf.assign_item("p", 9, "bob", entity_type="issue", session_id=session)
         assert result["entity_type"] == "issue"
-        mock_client.api.issues.edit.assert_called_once_with(300, assigned_to=7, version=1)
+        # Issues.edit(id, version, data) — must be data={...}, not an assigned_to kwarg (#123)
+        mock_client.api.issues.edit.assert_called_once_with(300, version=1, data={"assigned_to": 7})
+
+    def test_assigns_task_via_entity_type(self, session, mock_client):
+        mock_client.api.get.return_value = {"id": 1, "slug": "p", "name": "P"}
+        mock_client.list_resources.return_value = [
+            {
+                "user": 7,
+                "full_name": "Bob",
+                "email": "bob@x",
+                "user_extra_info": {"username": "bob"},
+            }
+        ]
+        mock_client.api.tasks.get_by_ref.return_value = {"id": 400, "version": 3}
+        mock_client.api.tasks.edit.return_value = {
+            "assigned_to_extra_info": {"full_name_display": "Bob"}
+        }
+        result = wf.assign_item("p", 12, "bob", entity_type="task", session_id=session)
+        assert result["entity_type"] == "task"
+        # Tasks.edit(id, version, data) — same data={...} requirement as issues (#123)
+        mock_client.api.tasks.edit.assert_called_once_with(400, version=3, data={"assigned_to": 7})
+
+    def test_assigns_epic_via_entity_type(self, session, mock_client):
+        mock_client.api.get.return_value = {"id": 1, "slug": "p", "name": "P"}
+        mock_client.list_resources.return_value = [
+            {
+                "user": 7,
+                "full_name": "Bob",
+                "email": "bob@x",
+                "user_extra_info": {"username": "bob"},
+            }
+        ]
+        mock_client.api.epics.get_by_ref.return_value = {"id": 500, "version": 4}
+        mock_client.api.epics.edit.return_value = {
+            "assigned_to_extra_info": {"full_name_display": "Bob"}
+        }
+        result = wf.assign_item("p", 20, "bob", entity_type="epic", session_id=session)
+        assert result["entity_type"] == "epic"
+        # Epics.edit(id, version, **kwargs) — kwargs path, like user stories (#123)
+        mock_client.api.epics.edit.assert_called_once_with(500, version=4, assigned_to=7)
 
     def test_invalid_entity_type_raises(self, session, mock_client):
         with pytest.raises(ValueError, match="Invalid entity_type"):


### PR DESCRIPTION
Fixes #123.

## Problem
`assign_item` (workflow) works for **stories** but raises for **issues** and **tasks**:
```
Issues.edit() got an unexpected keyword argument 'assigned_to'
```
It used one generic edit for all types (`server_workflow.py`):
```python
collection.edit(current["id"], assigned_to=user_id, version=current["version"])
```
But pytaigaclient's `edit()` signatures diverge:

| Resource | Signature | `assigned_to=` kwarg? |
|---|---|---|
| `user_stories.edit` / `epics.edit` | `edit(id, version, **kwargs)` | ✅ |
| `tasks.edit` / `issues.edit` | `edit(id, version, data: Dict)` | ❌ needs `data={...}` |

So only `story`/`epic` worked. (The `update_issue`/`update_task` tools already use `data=` correctly.)

## Fix
Route the edit per resource in `assign_item`: `data={"assigned_to": user_id}` for tasks/issues, `assigned_to=` kwarg for user_stories/epics.

## Why it slipped past tests
`test_assigns_issue_via_entity_type` mocked `issues.edit` as a bare `MagicMock` (accepts any kwargs) and even asserted the buggy `edit(300, assigned_to=7, version=1)` call. Tightened it to assert `data={"assigned_to": 7}`, and added **task** (data=) and **epic** (kwargs) cases so both branches are covered.

## Verification
- 535 tests pass; `ruff check` + `format` clean; pre-commit hooks green.
- Confirmed live via the `update_issue` workaround (issue #1264 assigned) — this PR makes `assign_item` itself work for issues/tasks.

## Context
Follow-up to #120/#121 (that fixed a *different* bug — null-field crash in `_resolve_user`). This one is the edit-signature mismatch, surfaced while assigning a real issue post-deploy.