### PR TITLE
feat: return description on single-item get_story/get_task/get_issue (workflow mode)

### DIFF
--- a/src/server_workflow.py
+++ b/src/server_workflow.py
@@ -860,7 +860,9 @@ def get_issue(
         issue = client.api.issues.get_by_ref(ref=ref, project=proj["id"])
         if not issue:
             raise ValueError(f"Issue #{ref} not found in project '{proj['slug']}'.")
-        # Single-item read: include the full description (see get_story rationale).
+        # Single-item read: include the full description. Kept off the shared
+        # _issue_summary shape for consistency with get_story/get_task, whose
+        # helpers are reused by lean board/list composites.
         result = _issue_summary(issue)
         result["description"] = issue.get("description")
         return result
@@ -1807,8 +1809,9 @@ def close_sprint(
 @mcp.tool(
     "get_epic_overview",
     description=(
-        "Return an epic and all user stories linked to it, with per-status counts. "
-        "ref is the epic ref number. project accepts slug or ID."
+        "Return an epic (including its full description) and all user stories linked "
+        "to it, with per-status counts. ref is the epic ref number. project accepts "
+        "slug or ID."
     ),
 )
 def get_epic_overview(
@@ -1845,6 +1848,7 @@ def get_epic_overview(
                 "status": (epic.get("status_extra_info") or {}).get("name"),
                 "assignee": (epic.get("assigned_to_extra_info") or {}).get("full_name_display"),
                 "color": epic.get("color"),
+                "description": epic.get("description"),
             },
             "summary": {
                 "total_stories": len(stories),

--- a/src/server_workflow.py
+++ b/src/server_workflow.py
@@ -781,8 +781,8 @@ def search(
     "get_story",
     description=(
         "Read a single user story by its ref number. Returns resolved human fields "
-        "(status name, is_closed, assignee, sprint, tags) — no mutation. "
-        "project accepts slug or ID."
+        "(status name, is_closed, assignee, sprint, tags) plus the full description "
+        "— no mutation. project accepts slug or ID."
     ),
 )
 def get_story(
@@ -798,7 +798,12 @@ def get_story(
         story = client.api.user_stories.get_by_ref(ref=ref, project=proj["id"])
         if not story:
             raise ValueError(f"User story #{ref} not found in project '{proj['slug']}'.")
-        return _story_summary(story)
+        # Single-item read: include the full description. The shared _story_summary
+        # helper stays lean (it is reused by list/board composites where the
+        # description would bloat every row).
+        result = _story_summary(story)
+        result["description"] = story.get("description")
+        return result
 
     return _execute_taiga_operation("get_story", do_get, f"#{ref} in {project}")
 
@@ -807,7 +812,8 @@ def get_story(
     "get_task",
     description=(
         "Read a single task by its ref number. Returns resolved human fields "
-        "(status name, is_closed, assignee) — no mutation. project accepts slug or ID."
+        "(status name, is_closed, assignee) plus the full description — no mutation. "
+        "project accepts slug or ID."
     ),
 )
 def get_task(
@@ -825,7 +831,10 @@ def get_task(
         task = client.api.get("/tasks/by_ref", params={"ref": ref, "project": proj["id"]})
         if not task:
             raise ValueError(f"Task #{ref} not found in project '{proj['slug']}'.")
-        return _task_summary(task)
+        # Single-item read: include the full description (see get_story rationale).
+        result = _task_summary(task)
+        result["description"] = task.get("description")
+        return result
 
     return _execute_taiga_operation("get_task", do_get, f"task #{ref} in {project}")
 
@@ -834,8 +843,8 @@ def get_task(
     "get_issue",
     description=(
         "Read a single issue by its ref number. Returns resolved human fields "
-        "(status name, is_closed, assignee, priority, severity, type, tags) — no mutation. "
-        "project accepts slug or ID."
+        "(status name, is_closed, assignee, priority, severity, type, tags) plus the "
+        "full description — no mutation. project accepts slug or ID."
     ),
 )
 def get_issue(
@@ -851,7 +860,10 @@ def get_issue(
         issue = client.api.issues.get_by_ref(ref=ref, project=proj["id"])
         if not issue:
             raise ValueError(f"Issue #{ref} not found in project '{proj['slug']}'.")
-        return _issue_summary(issue)
+        # Single-item read: include the full description (see get_story rationale).
+        result = _issue_summary(issue)
+        result["description"] = issue.get("description")
+        return result
 
     return _execute_taiga_operation("get_issue", do_get, f"#{ref} in {project}")
 

--- a/tests/test_server_workflow.py
+++ b/tests/test_server_workflow.py
@@ -2661,3 +2661,75 @@ class TestSessionTools:
     def test_session_status_not_found(self):
         result = wf.session_status(session_id="ghost")
         assert result == {"status": "inactive", "reason": "not_found", "session_id": "ghost"}
+
+
+class TestSingleItemGettersReturnDescription:
+    """get_story / get_task / get_issue must surface the full `description` on a
+    single-item read (the shared *_summary helpers omit it to keep board/list
+    rows lean). Regression guard: the summary discarded description, forcing a
+    REST-API detour to read it."""
+
+    def _project(self):
+        return {"id": 1, "slug": "p", "name": "P"}
+
+    def test_get_story_includes_description(self, session, mock_client):
+        mock_client.api.get.return_value = self._project()
+        mock_client.api.user_stories.get_by_ref.return_value = {
+            "id": 50,
+            "ref": 3,
+            "subject": "Story A",
+            "description": "The full story description.",
+            "status_extra_info": {"name": "New"},
+            "assigned_to_extra_info": {"full_name_display": "Alice"},
+            "tags": [],
+        }
+        result = wf.get_story("p", 3, session_id=session)
+        assert result["description"] == "The full story description."
+        # summary fields still present
+        assert result["ref"] == 3
+        assert result["subject"] == "Story A"
+
+    def test_get_story_null_description_surfaced_as_none(self, session, mock_client):
+        mock_client.api.get.return_value = self._project()
+        mock_client.api.user_stories.get_by_ref.return_value = {"id": 50, "ref": 3}
+        result = wf.get_story("p", 3, session_id=session)
+        assert "description" in result
+        assert result["description"] is None
+
+    def test_get_task_includes_description(self, session, mock_client):
+        task = {
+            "id": 200,
+            "ref": 7,
+            "subject": "Task 1",
+            "description": "Task detail.",
+            "status_extra_info": {"name": "New"},
+        }
+
+        def api_get(path, params=None):
+            if "/tasks/by_ref" in str(path):
+                return task
+            return self._project()
+
+        mock_client.api.get.side_effect = api_get
+        result = wf.get_task("p", 7, session_id=session)
+        assert result["description"] == "Task detail."
+        assert result["ref"] == 7
+
+    def test_get_issue_includes_description(self, session, mock_client):
+        mock_client.api.get.return_value = self._project()
+        mock_client.api.issues.get_by_ref.return_value = {
+            "id": 300,
+            "ref": 5,
+            "subject": "Bug",
+            "description": "Issue detail.",
+            "status_extra_info": {"name": "New"},
+            "tags": [],
+        }
+        result = wf.get_issue("p", 5, session_id=session)
+        assert result["description"] == "Issue detail."
+        assert result["ref"] == 5
+
+    def test_story_summary_helper_stays_lean(self):
+        """The shared helper must NOT gain description (boards/lists reuse it)."""
+        summary = wf._story_summary({"ref": 1, "subject": "X", "description": "big blob"})
+        assert "description" not in summary

--- a/tests/test_server_workflow.py
+++ b/tests/test_server_workflow.py
@@ -2729,7 +2729,51 @@ class TestSingleItemGettersReturnDescription:
         assert result["description"] == "Issue detail."
         assert result["ref"] == 5
 
-    def test_story_summary_helper_stays_lean(self):
-        """The shared helper must NOT gain description (boards/lists reuse it)."""
-        summary = wf._story_summary({"ref": 1, "subject": "X", "description": "big blob"})
-        assert "description" not in summary
+    def test_get_task_null_description_surfaced_as_none(self, session, mock_client):
+        task = {"id": 200, "ref": 7}
+
+        def api_get(path, params=None):
+            if "/tasks/by_ref" in str(path):
+                return task
+            return self._project()
+
+        mock_client.api.get.side_effect = api_get
+        result = wf.get_task("p", 7, session_id=session)
+        assert "description" in result
+        assert result["description"] is None
+
+    def test_get_issue_null_description_surfaced_as_none(self, session, mock_client):
+        mock_client.api.get.return_value = self._project()
+        mock_client.api.issues.get_by_ref.return_value = {"id": 300, "ref": 5}
+        result = wf.get_issue("p", 5, session_id=session)
+        assert "description" in result
+        assert result["description"] is None
+
+    def test_get_epic_overview_includes_epic_description(self, session, mock_client):
+        epic = {
+            "id": 900,
+            "ref": 12,
+            "subject": "Epic X",
+            "description": "Epic-level description.",
+            "status_extra_info": {"name": "New"},
+        }
+
+        def api_get(path, params=None):
+            if "/epics/by_ref" in str(path):
+                return epic
+            return self._project()
+
+        mock_client.api.get.side_effect = api_get
+        mock_client.list_resources.return_value = []
+        result = wf.get_epic_overview("p", 12, session_id=session)
+        assert result["epic"]["description"] == "Epic-level description."
+        assert result["epic"]["ref"] == 12
+
+    def test_summary_helpers_stay_lean(self):
+        """The shared *_summary helpers must NOT gain description — they are reused
+        by list/board composites (get_sprint_board reuses both story + task) where
+        a full description per row would bloat responses."""
+        blob = {"ref": 1, "subject": "X", "description": "big blob"}
+        assert "description" not in wf._story_summary(blob)
+        assert "description" not in wf._task_summary(blob)
+        assert "description" not in wf._issue_summary(blob)


### PR DESCRIPTION
## Problem

In **workflow mode** (default), `get_story` / `get_task` / `get_issue` fetch the full entity from the Taiga API — which **includes `description`** — then pass it through the shared `_story_summary` / `_task_summary` / `_issue_summary` helpers, which return a fixed field set that **omits `description`**. There is no param or verbosity option, so **there is no way to read an entity's description in workflow mode**. Callers must fall back to the raw Taiga REST API.

(Full mode already returns it — `RESPONSE_FIELDS["user_story"]["standard"]` includes `description` — but flipping `TAIGA_SERVER_MODE=full` swaps the whole 28-tool intent surface for 107 CRUD tools just to read one field.)

Discovered while rewriting a user-story description via the MCP: the write succeeded but couldn't be verified, and the pre-existing description couldn't be read back.

## Change

Attach `description` onto the result of the **three single-item getters only**:

```python
result = _story_summary(story)
result["description"] = story.get("description")
return result
```

The shared `_*_summary` helpers are **left lean by design** — they're reused by `get_sprint_board`, `browse_backlog`, and other list/board composites (lines 903/1060/1215/1552/1823), where a full description per row would bloat responses. Scoping the field to deliberate single-item reads keeps boards lean while making `get_*` self-sufficient.

Tool descriptions updated to mention the returned description. `get_epic` is not affected (no single-item epic getter exists in workflow mode).

## Tests

New `TestSingleItemGettersReturnDescription`:
- `get_story` / `get_task` / `get_issue` return `description`
- null description surfaces as `None` (key present)
- **regression guard** that `_story_summary` stays lean (must NOT gain `description`)

Full unit suite green: **540 passed** (`pytest -m "not integration"`); ruff check + format clean; pre-commit hooks pass.