### PR TITLE
fix(extra_info): stop reading *_extra_info keys Taiga never publishes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ src/
   config.py          — Pydantic settings (env vars, SecretStr credentials)
 ```
 
-- `server_workflow.py` — intent-oriented tools that accept human-readable names (project slug, sprint name, status name, username) and resolve them internally. Tools composite multiple API calls to answer PO-level questions in one step.
+- `server_workflow.py` — intent-oriented tools that accept human-readable names (project slug, sprint name, status name, member email or full name) and resolve them internally. Note: Taiga `/memberships` exposes no username field, so user resolution matches on `user_email` / `email` / `full_name` only. Tools composite multiple API calls to answer PO-level questions in one step.
 - `server_full.py` — 1:1 mapping of Taiga REST API. Tools are grouped by resource type: auth, projects, user stories, tasks, issues, epics, milestones, wiki, memberships, comments.
 - `taiga_client.py` wraps `pytaigaclient.TaigaClient` and adds `list_resources()` with `x-disable-pagination` header.
 - Session management: `active_sessions` dict keyed by UUID (or `"default"` for auto-auth).

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The bridge ships two servers in a single image. Select one at runtime via the `T
 | `workflow` (default) | ~34 intent tools | Product Owners and team members managing projects daily |
 | `full` | 107 CRUD tools | Automation scripts, admin tasks, full API access |
 
-**Workflow mode** (default) accepts human-readable names everywhere — project slug, sprint name, status name, username — and resolves them internally. One call to `get_sprint_board` returns a complete board view with all stories and tasks; `plan_sprint` creates a sprint and assigns stories in a single step.
+**Workflow mode** (default) accepts human-readable names everywhere — project slug, sprint name, status name, member email or full name — and resolves them internally. One call to `get_sprint_board` returns a complete board view with all stories and tasks; `plan_sprint` creates a sprint and assigns stories in a single step.
 
 **Full mode** gives direct access to every Taiga API endpoint. Useful when you need precise control, bulk operations, or access to resources not surfaced in workflow mode (swimlanes, custom attributes, attachments, story points).
 
@@ -77,7 +77,7 @@ Intent-based tools that resolve names and composite API calls:
 | `get_epic_overview` | Epic + all linked stories with progress counts |
 | `create_epic` | Create epic + optionally link existing stories |
 | `get_team_workload` | Per-member story/task counts for a sprint |
-| `assign_item` | Assign any entity by username |
+| `assign_item` | Assign any entity by member email or full name |
 | `get_wiki` / `upsert_wiki` | Get or create/update wiki pages |
 | `add_comment` | Comment on any entity by ref |
 | `search` | Full-text search across all entity types (status resolved to name + `is_closed`) |

--- a/src/server_full.py
+++ b/src/server_full.py
@@ -1309,8 +1309,8 @@ def _resolve_assignee_id(
     """Resolve ``user`` to a Taiga user ID for the assign_* tools.
 
     Ints pass through unchanged (backward-compatible with the historical
-    ``user_id: int`` API — no extra API calls). Strings are treated as a
-    username / email / full name and resolved against the members of the
+    ``user_id: int`` API — no extra API calls). Strings are treated as an
+    email / full name and resolved against the members of the
     entity's project (looked up from the entity), reusing the shared None-safe
     ``resolve_user_id`` so full mode gets the same robust resolution as
     workflow mode (pytaiga-mcp#120).
@@ -1325,12 +1325,12 @@ def _resolve_assignee_id(
 
 @mcp.tool(
     "assign_user_story_to_user",
-    description="Assigns a specific user story to a user. `user` accepts a numeric user ID or a username/email/full name (resolved against the project's members). Uses default session if session_id not provided.",
+    description="Assigns a specific user story to a user. `user` accepts a numeric user ID, or an email or full name (resolved against the project's members; Taiga memberships expose no username). Uses default session if session_id not provided.",
 )
 def assign_user_story_to_user(
     user_story_id: int, user: Union[int, str], session_id: Optional[str] = None
 ) -> Dict[str, Any]:
-    """Assigns a user story to a user (by ID or username/email/full name)."""
+    """Assigns a user story to a user (by ID, email, or full name)."""
     actual_session_id = _get_session_id(session_id)
     user_id = _resolve_assignee_id(user, "user_stories", user_story_id, actual_session_id)
     logger.info(
@@ -1565,12 +1565,12 @@ def delete_task(task_id: int, session_id: Optional[str] = None) -> Dict[str, Any
 
 @mcp.tool(
     "assign_task_to_user",
-    description="Assigns a specific task to a user. `user` accepts a numeric user ID or a username/email/full name (resolved against the project's members). Uses default session if session_id not provided.",
+    description="Assigns a specific task to a user. `user` accepts a numeric user ID, or an email or full name (resolved against the project's members; Taiga memberships expose no username). Uses default session if session_id not provided.",
 )
 def assign_task_to_user(
     task_id: int, user: Union[int, str], session_id: Optional[str] = None
 ) -> Dict[str, Any]:
-    """Assigns a task to a user (by ID or username/email/full name)."""
+    """Assigns a task to a user (by ID, email, or full name)."""
     actual_session_id = _get_session_id(session_id)
     user_id = _resolve_assignee_id(user, "tasks", task_id, actual_session_id)
     logger.info(
@@ -1798,12 +1798,12 @@ def delete_issue(issue_id: int, session_id: Optional[str] = None) -> Dict[str, A
 
 @mcp.tool(
     "assign_issue_to_user",
-    description="Assigns a specific issue to a user. `user` accepts a numeric user ID or a username/email/full name (resolved against the project's members). Uses default session if session_id not provided.",
+    description="Assigns a specific issue to a user. `user` accepts a numeric user ID, or an email or full name (resolved against the project's members; Taiga memberships expose no username). Uses default session if session_id not provided.",
 )
 def assign_issue_to_user(
     issue_id: int, user: Union[int, str], session_id: Optional[str] = None
 ) -> Dict[str, Any]:
-    """Assigns an issue to a user (by ID or username/email/full name)."""
+    """Assigns an issue to a user (by ID, email, or full name)."""
     actual_session_id = _get_session_id(session_id)
     user_id = _resolve_assignee_id(user, "issues", issue_id, actual_session_id)
     logger.info(
@@ -2856,12 +2856,12 @@ def delete_epic(epic_id: int, session_id: Optional[str] = None) -> Dict[str, Any
 
 @mcp.tool(
     "assign_epic_to_user",
-    description="Assigns a specific epic to a user. `user` accepts a numeric user ID or a username/email/full name (resolved against the project's members). Uses default session if session_id not provided.",
+    description="Assigns a specific epic to a user. `user` accepts a numeric user ID, or an email or full name (resolved against the project's members; Taiga memberships expose no username). Uses default session if session_id not provided.",
 )
 def assign_epic_to_user(
     epic_id: int, user: Union[int, str], session_id: Optional[str] = None
 ) -> Dict[str, Any]:
-    """Assigns an epic to a user (by ID or username/email/full name)."""
+    """Assigns an epic to a user (by ID, email, or full name)."""
     actual_session_id = _get_session_id(session_id)
     user_id = _resolve_assignee_id(user, "epics", epic_id, actual_session_id)
     logger.info(

--- a/src/server_full.py
+++ b/src/server_full.py
@@ -263,12 +263,12 @@ RESPONSE_FIELDS: Dict[str, Dict[str, Optional[List[str]]]] = {
             "description",
             "status",
             "status_extra_info",
+            # priority/severity/type are bare integer IDs. Taiga publishes no
+            # *_extra_info for them (only assigned_to/owner/project/status), so
+            # listing those keys here would be dead config.
             "priority",
-            "priority_extra_info",
             "severity",
-            "severity_extra_info",
             "type",
-            "type_extra_info",
             "assigned_to",
             "assigned_to_extra_info",
             "milestone",

--- a/src/server_workflow.py
+++ b/src/server_workflow.py
@@ -439,10 +439,24 @@ def _issue_summary(
     ``*_extra_info`` for them (see _name_for_issue_attribute). Pass client,
     project_id and session_id to get their names; without that context the raw
     IDs are returned rather than a misleading None.
+
+    The three context arguments are all-or-nothing: supplying a subset raises
+    rather than silently degrading to raw IDs, which would look like a successful
+    resolution to the caller.
     """
-    if client is not None and project_id is not None and session_id is not None:
+    context = (client, project_id, session_id)
+    if any(v is not None for v in context) and not all(v is not None for v in context):
+        raise ValueError(
+            "_issue_summary: client, project_id and session_id must be passed together "
+            "(or all omitted)."
+        )
+    if all(v is not None for v in context):
+        # Fall back to the raw ID when an ID is absent from the project's table,
+        # mirroring the `status` line below — an unresolvable value should degrade
+        # to something identifiable, not vanish.
         names = {
             attr: _name_for_issue_attribute(client, project_id, attr, issue.get(attr), session_id)
+            or issue.get(attr)
             for attr in ("priority", "severity", "type")
         }
     else:
@@ -1477,15 +1491,20 @@ def create_issue(
             "ref": result.get("ref"),
             "id": result.get("id"),
             "subject": result.get("subject"),
+            # `or result.get(...)` degrades an unresolvable ID to the raw integer
+            # rather than None — see _issue_summary.
             "type": _name_for_issue_attribute(
                 client, project_id, "type", result.get("type"), actual_session_id
-            ),
+            )
+            or result.get("type"),
             "priority": _name_for_issue_attribute(
                 client, project_id, "priority", result.get("priority"), actual_session_id
-            ),
+            )
+            or result.get("priority"),
             "severity": _name_for_issue_attribute(
                 client, project_id, "severity", result.get("severity"), actual_session_id
-            ),
+            )
+            or result.get("severity"),
         }
 
     return _execute_taiga_operation("create_issue", do_create, str(project))
@@ -1562,15 +1581,19 @@ def update_issue(
             "ref": result.get("ref"),
             "subject": result.get("subject"),
             "status": (result.get("status_extra_info") or {}).get("name"),
+            # Raw-ID fallback on unresolvable IDs — see _issue_summary.
             "priority": _name_for_issue_attribute(
                 client, project_id, "priority", result.get("priority"), actual_session_id
-            ),
+            )
+            or result.get("priority"),
             "severity": _name_for_issue_attribute(
                 client, project_id, "severity", result.get("severity"), actual_session_id
-            ),
+            )
+            or result.get("severity"),
             "type": _name_for_issue_attribute(
                 client, project_id, "type", result.get("type"), actual_session_id
-            ),
+            )
+            or result.get("type"),
             "assignee": (result.get("assigned_to_extra_info") or {}).get("full_name_display"),
             "is_blocked": result.get("is_blocked"),
             "is_closed": result.get("is_closed", False),

--- a/src/server_workflow.py
+++ b/src/server_workflow.py
@@ -336,6 +336,38 @@ def _resolve_issue_attribute(
     return matches[0]["id"]
 
 
+def _name_for_issue_attribute(
+    client: TaigaClientWrapper,
+    project_id: int,
+    attr_type: str,
+    attr_id: Optional[int],
+    session_id: str,
+) -> Optional[str]:
+    """Resolve an issue priority/severity/type ID back to its name.
+
+    Taiga exposes NO ``priority_extra_info`` / ``severity_extra_info`` /
+    ``type_extra_info`` on its issue serializer — the only ``*_extra_info``
+    objects it returns are ``assigned_to``, ``owner``, ``project`` and
+    ``status``. These three fields come back as bare integer IDs, so reading a
+    ``*_extra_info`` key for them silently yields None on every call and makes a
+    correctly-set field look unset. Reverse-map the ID instead.
+
+    Reads the same session cache that ``_resolve_issue_attribute`` populates, so
+    this costs no extra API request after the first lookup per project.
+    """
+    if attr_id is None:
+        return None
+    resource = _ISSUE_ATTR_RESOURCE_MAP.get(attr_type)
+    if not resource:
+        raise ValueError(f"Unknown attribute type '{attr_type}'.")
+    items = _cached(
+        session_id,
+        f"{resource}_{project_id}",
+        lambda: client.list_resources(resource, project_id=project_id),
+    )
+    return next((i.get("name") for i in items if i.get("id") == attr_id), None)
+
+
 def _resolve_story_refs(client: TaigaClientWrapper, project_id: int, refs: List[int]) -> List[int]:
     """Resolve a list of user story ref numbers to IDs with a single API call.
 
@@ -377,7 +409,9 @@ def _story_summary(us: Dict[str, Any]) -> Dict[str, Any]:
         "assignee": (us.get("assigned_to_extra_info") or {}).get("full_name_display"),
         "is_blocked": us.get("is_blocked", False),
         "is_closed": _is_closed(us),
-        "sprint": (us.get("milestone_extra_info") or {}).get("name"),
+        # Taiga publishes NO milestone_extra_info on user stories — the sprint
+        # arrives as `milestone` (ID) plus flat `milestone_name`/`milestone_slug`.
+        "sprint": us.get("milestone_name") or us.get("milestone_slug"),
         "tags": us.get("tags", []),
     }
 
@@ -393,16 +427,34 @@ def _task_summary(task: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
-def _issue_summary(issue: Dict[str, Any]) -> Dict[str, Any]:
-    """Extract readable fields from a raw issue dict (resolved names, not raw ids)."""
+def _issue_summary(
+    issue: Dict[str, Any],
+    client: Optional[TaigaClientWrapper] = None,
+    project_id: Optional[int] = None,
+    session_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Extract readable fields from a raw issue dict (resolved names, not raw ids).
+
+    priority/severity/type arrive as bare integer IDs — Taiga publishes no
+    ``*_extra_info`` for them (see _name_for_issue_attribute). Pass client,
+    project_id and session_id to get their names; without that context the raw
+    IDs are returned rather than a misleading None.
+    """
+    if client is not None and project_id is not None and session_id is not None:
+        names = {
+            attr: _name_for_issue_attribute(client, project_id, attr, issue.get(attr), session_id)
+            for attr in ("priority", "severity", "type")
+        }
+    else:
+        names = {attr: issue.get(attr) for attr in ("priority", "severity", "type")}
     return {
         "ref": issue.get("ref"),
         "subject": issue.get("subject"),
         "status": (issue.get("status_extra_info") or {}).get("name") or issue.get("status"),
         "assignee": (issue.get("assigned_to_extra_info") or {}).get("full_name_display"),
-        "priority": (issue.get("priority_extra_info") or {}).get("name"),
-        "severity": (issue.get("severity_extra_info") or {}).get("name"),
-        "type": (issue.get("type_extra_info") or {}).get("name"),
+        "priority": names["priority"],
+        "severity": names["severity"],
+        "type": names["type"],
         "is_blocked": issue.get("is_blocked", False),
         "is_closed": _is_closed(issue),
         "tags": issue.get("tags", []),
@@ -662,9 +714,13 @@ def get_project_overview(
 
         # Team
         members = client.list_resources("memberships", project_id=project_id)
+        # Memberships carry NO user_extra_info (and no username at all). Identity
+        # comes from flat fields: `user_email` is the reliable one — `email` is
+        # often blank on established members. Email is also what user resolution
+        # matches on, so it is the useful handle to surface here.
         team = [
             {
-                "username": (m.get("user_extra_info") or {}).get("username"),
+                "email": m.get("user_email") or m.get("email"),
                 "full_name": m.get("full_name"),
                 "role": m.get("role_name"),
                 "is_admin": m.get("is_admin", False),
@@ -863,7 +919,7 @@ def get_issue(
         # Single-item read: include the full description. Kept off the shared
         # _issue_summary shape for consistency with get_story/get_task, whose
         # helpers are reused by lean board/list composites.
-        result = _issue_summary(issue)
+        result = _issue_summary(issue, client, proj["id"], actual_session_id)
         result["description"] = issue.get("description")
         return result
 
@@ -978,7 +1034,8 @@ def create_story(
             "ref": result.get("ref"),
             "id": result.get("id"),
             "subject": result.get("subject"),
-            "sprint": (result.get("milestone_extra_info") or {}).get("name"),
+            # No milestone_extra_info on user stories — see _story_summary.
+            "sprint": result.get("milestone_name") or result.get("milestone_slug"),
             "epic_linked": epic is not None,
         }
 
@@ -1420,9 +1477,15 @@ def create_issue(
             "ref": result.get("ref"),
             "id": result.get("id"),
             "subject": result.get("subject"),
-            "type": (result.get("type_extra_info") or {}).get("name"),
-            "priority": (result.get("priority_extra_info") or {}).get("name"),
-            "severity": (result.get("severity_extra_info") or {}).get("name"),
+            "type": _name_for_issue_attribute(
+                client, project_id, "type", result.get("type"), actual_session_id
+            ),
+            "priority": _name_for_issue_attribute(
+                client, project_id, "priority", result.get("priority"), actual_session_id
+            ),
+            "severity": _name_for_issue_attribute(
+                client, project_id, "severity", result.get("severity"), actual_session_id
+            ),
         }
 
     return _execute_taiga_operation("create_issue", do_create, str(project))
@@ -1499,9 +1562,15 @@ def update_issue(
             "ref": result.get("ref"),
             "subject": result.get("subject"),
             "status": (result.get("status_extra_info") or {}).get("name"),
-            "priority": (result.get("priority_extra_info") or {}).get("name"),
-            "severity": (result.get("severity_extra_info") or {}).get("name"),
-            "type": (result.get("type_extra_info") or {}).get("name"),
+            "priority": _name_for_issue_attribute(
+                client, project_id, "priority", result.get("priority"), actual_session_id
+            ),
+            "severity": _name_for_issue_attribute(
+                client, project_id, "severity", result.get("severity"), actual_session_id
+            ),
+            "type": _name_for_issue_attribute(
+                client, project_id, "type", result.get("type"), actual_session_id
+            ),
             "assignee": (result.get("assigned_to_extra_info") or {}).get("full_name_display"),
             "is_blocked": result.get("is_blocked"),
             "is_closed": result.get("is_closed", False),

--- a/src/server_workflow.py
+++ b/src/server_workflow.py
@@ -3,7 +3,7 @@
 Exposes ~28 intent-based tools designed for everyday project management:
 sprint planning, backlog grooming, team workload, epic tracking, task
 breakdown, wiki, and comments. All tools accept human-readable names
-(project slug, sprint name, status name, username) and resolve them to
+(project slug, sprint name, status name, user email) and resolve them to
 API IDs internally.
 
 Start with:
@@ -282,7 +282,11 @@ def _resolve_user(
     username: str,
     session_id: str,
 ) -> int:
-    """Resolve a username, email, or full name to a user ID within project members."""
+    """Resolve an email or full name to a user ID within project members.
+
+    Resolution runs against ``/memberships``, which exposes no username field —
+    see ``resolve_user_id``. The parameter name is historical.
+    """
     members = _cached(
         session_id,
         f"members_{project_id}",
@@ -949,7 +953,7 @@ def get_issue(
     "browse_backlog",
     description=(
         "List user stories in the backlog (not assigned to any sprint) with optional filters. "
-        "Filters: status (name), assignee (username/email), epic (ref number), tags (comma-separated). "
+        "Filters: status (name), assignee (email/full name), epic (ref number), tags (comma-separated). "
         "project accepts slug or ID."
     ),
 )
@@ -993,7 +997,7 @@ def browse_backlog(
     "create_story",
     description=(
         "Create a user story in the backlog with optional epic link, sprint assignment, and assignee. "
-        "project accepts slug or ID. assignee accepts username or email. "
+        "project accepts slug or ID. assignee accepts an email or full name. "
         "sprint accepts name or ID (omit to place in backlog). epic accepts ref number."
     ),
 )
@@ -1161,7 +1165,7 @@ def update_story(
         "Add a single task under an existing user story. story_ref is the parent US ref number. "
         "By default the task inherits the parent story's sprint; pass sprint=<name|id> to "
         "place the task in a different sprint, or sprint=0 to keep it out of any sprint. "
-        "All name fields are resolved (assignee username, status name, sprint name). "
+        "All name fields are resolved (assignee email/full name, status name, sprint name). "
         "project accepts slug or ID."
     ),
 )
@@ -1422,7 +1426,7 @@ def break_down_story(
     "create_issue",
     description=(
         "Create a new issue. type, priority, and severity default to the project's first configured value "
-        "when not provided. All name fields are resolved (project slug, assignee username). "
+        "when not provided. All name fields are resolved (project slug, assignee email/full name). "
         "project accepts slug or ID."
     ),
 )
@@ -1956,7 +1960,7 @@ def get_epic_overview(
     "create_epic",
     description=(
         "Create a new epic and optionally link existing user stories to it by ref number. "
-        "assignee accepts username or email. story_refs is a list of existing US ref numbers to link. "
+        "assignee accepts an email or full name. story_refs is a list of existing US ref numbers to link. "
         "project accepts slug or ID."
     ),
 )
@@ -2073,7 +2077,9 @@ def get_team_workload(
 @mcp.tool(
     "assign_item",
     description=(
-        "Assign a user story, task, issue, or epic to a team member by username or email. "
+        "Assign a user story, task, issue, or epic to a team member by email or full name. "
+        "The `username` parameter name is historical — Taiga memberships expose no "
+        "username, so pass an email address or the member's full name. "
         "entity_type: 'story' (default), 'task', 'issue', or 'epic'. "
         "ref is the item ref number. project accepts slug or ID."
     ),

--- a/src/taiga_client.py
+++ b/src/taiga_client.py
@@ -47,10 +47,15 @@ def resolve_user_id(members: List[Dict[str, Any]], identifier: "int | str") -> i
     """Resolve a user identifier to a Taiga user ID against a project's memberships.
 
     ``identifier`` may be an ``int`` (returned unchanged — treated as a user ID)
-    or a string matched case-insensitively against each member's username, email,
-    full name, or display name. Matching is None-safe (see ``safe_lower``): a
-    single member with a null field no longer aborts resolution before the
-    intended user is reached.
+    or a string matched case-insensitively against each member's email or full
+    name. Matching is None-safe (see ``safe_lower``): a single member with a null
+    field no longer aborts resolution before the intended user is reached.
+
+    Membership rows carry NO ``user_extra_info`` and no ``username`` field, so
+    those lookups are kept only for forward-compatibility with endpoints that do
+    return them — they never match on a memberships payload. ``user_email`` is
+    the reliable address: the flat ``email`` field is frequently blank on
+    established members, which is why email resolution needs both.
 
     Raises ``ValueError`` if the identifier is empty or not found.
     """
@@ -65,6 +70,7 @@ def resolve_user_id(members: List[Dict[str, Any]], identifier: "int | str") -> i
         info = m.get("user_extra_info") or {}
         if needle in (
             safe_lower(info.get("username")),
+            safe_lower(m.get("user_email")),
             safe_lower(m.get("email")),
             safe_lower(m.get("full_name")),
             safe_lower(info.get("full_name_display")),
@@ -72,7 +78,9 @@ def resolve_user_id(members: List[Dict[str, Any]], identifier: "int | str") -> i
             uid = m.get("user")
             if uid is not None:
                 return uid
-    available = [m.get("full_name") or m.get("email") or "?" for m in members]
+    available = [
+        m.get("full_name") or m.get("user_email") or m.get("email") or "?" for m in members
+    ]
     raise ValueError(f"User '{identifier}' not found in project. Members: {available}")
 
 

--- a/src/taiga_client.py
+++ b/src/taiga_client.py
@@ -47,9 +47,11 @@ def resolve_user_id(members: List[Dict[str, Any]], identifier: "int | str") -> i
     """Resolve a user identifier to a Taiga user ID against a project's memberships.
 
     ``identifier`` may be an ``int`` (returned unchanged — treated as a user ID)
-    or a string matched case-insensitively against each member's email or full
-    name. Matching is None-safe (see ``safe_lower``): a single member with a null
-    field no longer aborts resolution before the intended user is reached.
+    or a string matched case-insensitively against each member's ``user_email``,
+    ``email``, ``full_name``, or — on non-memberships payloads only — the
+    ``user_extra_info`` username / display name. Matching is None-safe (see
+    ``safe_lower``): a single member with a null field no longer aborts resolution
+    before the intended user is reached.
 
     Membership rows carry NO ``user_extra_info`` and no ``username`` field, so
     those lookups are kept only for forward-compatibility with endpoints that do

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -722,18 +722,24 @@ class TestTaigaTools:
             user_story_id=456, version=1, assigned_to=10
         )
 
-    def test_assign_user_story_to_user_by_username(self, session_setup):
-        """assign_*_to_user resolves a username to an ID via the entity's project members."""
+    def test_assign_user_story_to_user_by_email(self, session_setup):
+        """assign_*_to_user resolves an email to an ID via the entity's project members.
+
+        Previously asserted resolution from the bare username "bob", which only
+        worked because the fixture supplied a phantom ``user_extra_info``.
+        Memberships carry no username at all, so email (or full name) is the only
+        identifier that resolves against a real payload.
+        """
         session_id, mock_client = session_setup
         mock_client.get_resource.return_value = {"id": 456, "project": 1}
         mock_client.list_resources.return_value = [
             # pending-invite member with null fields first — must not crash (pytaiga-mcp#120)
-            {"user": None, "email": None, "full_name": None, "user_extra_info": None},
+            {"user": None, "email": None, "user_email": None, "full_name": None},
             {
                 "user": 10,
-                "email": "bob@example.com",
+                "email": "",
+                "user_email": "bob@example.com",
                 "full_name": "Bob Stone",
-                "user_extra_info": {"username": "bob", "full_name_display": "Bob Stone"},
             },
         ]
         mock_client.api.user_stories.get.return_value = {
@@ -746,7 +752,7 @@ class TestTaigaTools:
             "assigned_to": 10,
             "version": 2,
         }
-        src_server.assign_user_story_to_user(456, "bob", session_id)
+        src_server.assign_user_story_to_user(456, "bob@example.com", session_id)
         mock_client.get_resource.assert_called_once_with("user_stories", 456)
         mock_client.api.user_stories.edit.assert_called_once_with(
             user_story_id=456, version=1, assigned_to=10

--- a/tests/test_server_workflow.py
+++ b/tests/test_server_workflow.py
@@ -305,29 +305,34 @@ class TestResolveStatus:
 
 class TestResolveUser:
     def _members(self):
+        """A REAL /memberships payload: no user_extra_info, no username, and the
+        flat `email` blank while `user_email` carries the address."""
         return [
             {
                 "user": 42,
                 "full_name": "Alice Martin",
-                "email": "alice@example.com",
-                "user_extra_info": {
-                    "username": "alice",
-                    "full_name_display": "Alice Martin",
-                },
+                "email": "",
+                "user_email": "alice@example.com",
             }
         ]
 
-    def test_resolves_by_username(self, mock_client):
-        mock_client.list_resources.return_value = self._members()
-        assert wf._resolve_user(mock_client, 1, "alice", "sess") == 42
-
-    def test_resolves_by_email(self, mock_client):
+    def test_resolves_by_user_email(self, mock_client):
+        # Memberships expose no username, so email is the practical handle.
         mock_client.list_resources.return_value = self._members()
         assert wf._resolve_user(mock_client, 1, "alice@example.com", "sess") == 42
 
     def test_resolves_by_full_name(self, mock_client):
         mock_client.list_resources.return_value = self._members()
         assert wf._resolve_user(mock_client, 1, "Alice Martin", "sess") == 42
+
+    def test_resolves_by_username_only_on_non_memberships_payload(self, mock_client):
+        # Forward-compat: resolution still probes user_extra_info for endpoints
+        # that return it. A memberships payload never does, so this shape is
+        # deliberately synthetic and must not be copied into other fixtures.
+        mock_client.list_resources.return_value = [
+            {"user": 7, "user_extra_info": {"username": "carol"}}
+        ]
+        assert wf._resolve_user(mock_client, 1, "CAROL", "sess") == 7
 
     def test_raises_when_not_found(self, mock_client):
         mock_client.list_resources.return_value = self._members()
@@ -336,14 +341,14 @@ class TestResolveUser:
 
     def test_resolves_past_member_with_null_fields(self, mock_client):
         # Regression for pytaiga-mcp#120: a pending-invite membership with null
-        # email/full_name/user_extra_info must not abort resolution before the
-        # valid member is reached (previously raised 'NoneType' ... 'lower').
+        # email/full_name must not abort resolution before the valid member is
+        # reached (previously raised 'NoneType' ... 'lower').
         members = [
-            {"user": None, "email": None, "full_name": None, "user_extra_info": None},
+            {"user": None, "email": None, "user_email": None, "full_name": None},
             *self._members(),
         ]
         mock_client.list_resources.return_value = members
-        assert wf._resolve_user(mock_client, 1, "alice", "sess") == 42
+        assert wf._resolve_user(mock_client, 1, "alice@example.com", "sess") == 42
 
     def test_int_identifier_passthrough(self, mock_client):
         mock_client.list_resources.return_value = self._members()
@@ -372,11 +377,27 @@ class TestCreateStory:
             "id": 100,
             "ref": 5,
             "subject": "As a user",
-            "milestone_extra_info": None,
         }
         result = wf.create_story("test", "As a user", session_id=session)
         assert result["status"] == "created"
         assert result["ref"] == 5
+        # No milestone on the created story -> no sprint, and notably not a crash
+        # from reaching into a phantom milestone_extra_info.
+        assert result["sprint"] is None
+
+    def test_returned_sprint_comes_from_flat_milestone_name(self, session, mock_client):
+        # create_story's own return block had the same phantom-key bug as
+        # _story_summary; cover it directly rather than only via the helper.
+        mock_client.api.get.return_value = {"id": 1, "slug": "test", "name": "Test"}
+        mock_client.api.user_stories.create.return_value = {
+            "id": 101,
+            "ref": 6,
+            "subject": "Sprinted",
+            "milestone": 85,
+            "milestone_name": "Sprint 9",
+        }
+        result = wf.create_story("test", "Sprinted", session_id=session)
+        assert result["sprint"] == "Sprint 9"
 
     def test_creates_story_with_assignee(self, session, mock_client):
         mock_client.api.get.return_value = {"id": 1, "slug": "test", "name": "Test"}
@@ -385,14 +406,12 @@ class TestCreateStory:
                 "user": 7,
                 "full_name": "Bob",
                 "email": "bob@example.com",
-                "user_extra_info": {"username": "bob", "full_name_display": "Bob"},
             }
         ]
         mock_client.api.user_stories.create.return_value = {
             "id": 200,
             "ref": 10,
             "subject": "Story",
-            "milestone_extra_info": None,
         }
         result = wf.create_story("test", "Story", assignee="bob", session_id=session)
         assert result["status"] == "created"
@@ -409,7 +428,6 @@ class TestCreateStory:
             "id": 100,
             "ref": 5,
             "subject": "Story",
-            "milestone_extra_info": None,
         }
         result = wf.create_story("test", "Story", epic=7, session_id=session)
         assert result["status"] == "created"
@@ -475,7 +493,7 @@ class TestGetSprintBoard:
                     "subject": "Story A",
                     "status_extra_info": {"name": "In Progress"},
                     "assigned_to_extra_info": {"full_name_display": "Alice"},
-                    "milestone_extra_info": {"name": "Sprint 1"},
+                    "milestone_name": "Sprint 1",
                     "is_blocked": False,
                     "is_closed": False,
                     "tags": [],
@@ -540,9 +558,6 @@ class TestUpdateIssue:
             "ref": 5,
             "subject": "Bug",
             "status_extra_info": {"name": "In Progress"},
-            "priority_extra_info": None,
-            "severity_extra_info": None,
-            "type_extra_info": None,
             "assigned_to_extra_info": None,
             "is_blocked": False,
         }
@@ -559,9 +574,7 @@ class TestUpdateIssue:
             "ref": 5,
             "subject": "Bug",
             "status_extra_info": None,
-            "priority_extra_info": {"name": "High"},
-            "severity_extra_info": None,
-            "type_extra_info": None,
+            "priority": 3,
             "assigned_to_extra_info": None,
             "is_blocked": False,
         }
@@ -584,9 +597,6 @@ class TestUpdateIssue:
             "ref": 5,
             "subject": "Bug",
             "status_extra_info": {"name": "Done"},
-            "priority_extra_info": None,
-            "severity_extra_info": None,
-            "type_extra_info": None,
             "assigned_to_extra_info": None,
             "is_blocked": False,
         }
@@ -689,7 +699,6 @@ class TestGetEpicOverviewBatched:
                 "subject": "Story A",
                 "status_extra_info": {"name": "Done"},
                 "assigned_to_extra_info": None,
-                "milestone_extra_info": None,
                 "is_blocked": False,
                 "is_closed": True,
                 "tags": [],
@@ -700,7 +709,6 @@ class TestGetEpicOverviewBatched:
                 "subject": "Story B",
                 "status_extra_info": {"name": "Done"},
                 "assigned_to_extra_info": None,
-                "milestone_extra_info": None,
                 "is_blocked": False,
                 "is_closed": True,
                 "tags": [],
@@ -842,7 +850,6 @@ class TestCreateTask:
                     "user": 7,
                     "full_name": "Alice",
                     "email": "alice@example.com",
-                    "user_extra_info": {"username": "alice", "full_name_display": "Alice"},
                 }
             ],
         ]
@@ -1103,7 +1110,6 @@ class TestBreakDownStory:
                 "user": 7,
                 "full_name": "Alice",
                 "email": "a@x",
-                "user_extra_info": {"username": "alice", "full_name_display": "Alice"},
             }
         ]
         mock_client.api.tasks.create.side_effect = [
@@ -1736,6 +1742,28 @@ class TestSearch:
         mock_client.list_resources.assert_called_once_with("epic_statuses", project_id=1)
 
 
+class TestStorySummary:
+    """_story_summary shape — the sprint field in particular."""
+
+    def test_sprint_comes_from_flat_milestone_name(self):
+        # Taiga sends no milestone_extra_info on user stories — the sprint is the
+        # flat milestone_name (slug as fallback). Reading the phantom key returned
+        # None for every story that had a sprint.
+        assert (
+            wf._story_summary({"ref": 1, "milestone": 85, "milestone_name": "Sprint 9"})["sprint"]
+            == "Sprint 9"
+        )
+
+    def test_sprint_falls_back_to_slug(self):
+        assert (
+            wf._story_summary({"ref": 2, "milestone": 85, "milestone_slug": "sprint-9"})["sprint"]
+            == "sprint-9"
+        )
+
+    def test_sprint_is_none_when_story_has_no_milestone(self):
+        assert wf._story_summary({"ref": 3})["sprint"] is None
+
+
 class TestGetStory:
     def test_returns_resolved_summary(self, session, mock_client):
         mock_client.api.get.return_value = {"id": 1, "slug": "p", "name": "P"}
@@ -1831,9 +1859,10 @@ class TestGetIssue:
         assert result["type"] == "Bug"
         mock_client.api.issues.get_by_ref.assert_called_once_with(ref=1212, project=1)
 
-    def test_unknown_attribute_id_yields_none_not_crash(self, session, mock_client):
+    def test_unknown_attribute_id_falls_back_to_raw_id(self, session, mock_client):
         # An ID absent from the project's table (stale cache, cross-project ref)
-        # must degrade to None rather than raising.
+        # must degrade to the raw ID — mirroring the `status` field — rather than
+        # raising or silently vanishing.
         mock_client.api.get.return_value = {"id": 1, "slug": "p", "name": "P"}
         mock_client.list_resources.side_effect = self._attr_lists()
         mock_client.api.issues.get_by_ref.return_value = {
@@ -1845,23 +1874,15 @@ class TestGetIssue:
             "type": 25,
         }
         result = wf.get_issue("p", 1213, session_id=session)
-        assert result["priority"] is None
+        assert result["priority"] == 9999
         assert result["severity"] is None
         assert result["type"] == "Bug"
 
-    def test_story_sprint_comes_from_flat_milestone_name(self):
-        # Taiga sends no milestone_extra_info on user stories — the sprint is the
-        # flat milestone_name (slug as fallback). Reading the phantom key returned
-        # None for every story that had a sprint.
-        assert (
-            wf._story_summary({"ref": 1, "milestone": 85, "milestone_name": "Sprint 9"})["sprint"]
-            == "Sprint 9"
-        )
-        assert (
-            wf._story_summary({"ref": 2, "milestone": 85, "milestone_slug": "sprint-9"})["sprint"]
-            == "sprint-9"
-        )
-        assert wf._story_summary({"ref": 3})["sprint"] is None
+    def test_partial_resolver_context_raises(self):
+        # All-or-nothing: a caller that passes client+project_id but forgets
+        # session_id must not silently receive raw IDs that look resolved.
+        with pytest.raises(ValueError, match="passed together"):
+            wf._issue_summary({"ref": 1}, client=object(), project_id=1)
 
     def test_summary_without_resolver_context_returns_raw_ids(self):
         # _issue_summary is also reachable without client/project context. It must
@@ -2011,7 +2032,6 @@ class TestCreateEpic:
                 "user": 7,
                 "full_name": "Bob",
                 "email": "bob@x",
-                "user_extra_info": {"username": "bob"},
             }
         ]
         mock_client.api.epics.create.return_value = {"id": 7, "ref": 70, "subject": "Big"}
@@ -2029,7 +2049,6 @@ class TestAssignItem:
                 "user": 7,
                 "full_name": "Bob",
                 "email": "bob@x",
-                "user_extra_info": {"username": "bob"},
             }
         ]
         mock_client.api.user_stories.get_by_ref.return_value = {"id": 100, "version": 2}
@@ -2047,7 +2066,6 @@ class TestAssignItem:
                 "user": 7,
                 "full_name": "Bob",
                 "email": "bob@x",
-                "user_extra_info": {"username": "bob"},
             }
         ]
         mock_client.api.issues.get_by_ref.return_value = {"id": 300, "version": 1}
@@ -2066,7 +2084,6 @@ class TestAssignItem:
                 "user": 7,
                 "full_name": "Bob",
                 "email": "bob@x",
-                "user_extra_info": {"username": "bob"},
             }
         ]
         mock_client.api.tasks.get_by_ref.return_value = {"id": 400, "version": 3}
@@ -2085,7 +2102,6 @@ class TestAssignItem:
                 "user": 7,
                 "full_name": "Bob",
                 "email": "bob@x",
-                "user_extra_info": {"username": "bob"},
             }
         ]
         mock_client.api.epics.get_by_ref.return_value = {"id": 500, "version": 4}
@@ -2470,7 +2486,6 @@ class TestBrowseBacklogFilters:
                         "user": 7,
                         "full_name": "Bob",
                         "email": "b@x",
-                        "user_extra_info": {"username": "bob"},
                     }
                 ],
                 "user_stories": [],
@@ -2506,7 +2521,6 @@ class TestCreateTaskOptionalFields:
                         "user": 7,
                         "full_name": "Bob",
                         "email": "b@x",
-                        "user_extra_info": {"username": "bob"},
                     }
                 ],
             }[resource]
@@ -2558,7 +2572,6 @@ class TestUpdateTaskBranches:
                         "user": 7,
                         "full_name": "Bob",
                         "email": "b@x",
-                        "user_extra_info": {"username": "bob"},
                     }
                 ],
                 "milestones": [{"id": 9, "name": "S1"}],
@@ -2625,7 +2638,6 @@ class TestCreateIssueAttributeResolution:
                         "user": 7,
                         "full_name": "Bob",
                         "email": "b@x",
-                        "user_extra_info": {"username": "bob"},
                     }
                 ],
                 "issue_statuses": [{"id": 40, "name": "New"}],
@@ -2670,7 +2682,6 @@ class TestUpdateIssueBranches:
                         "user": 7,
                         "full_name": "Bob",
                         "email": "b@x",
-                        "user_extra_info": {"username": "bob"},
                     }
                 ],
             }[resource]

--- a/tests/test_server_workflow.py
+++ b/tests/test_server_workflow.py
@@ -1793,15 +1793,33 @@ class TestGetTask:
 
 
 class TestGetIssue:
+    @staticmethod
+    def _attr_lists():
+        """side_effect for list_resources — the project's issue attribute tables."""
+        tables = {
+            "priorities": [{"id": 25, "name": "Low"}, {"id": 27, "name": "High"}],
+            "severities": [{"id": 43, "name": "Normal"}, {"id": 45, "name": "Critical"}],
+            "issue_types": [{"id": 25, "name": "Bug"}, {"id": 26, "name": "Question"}],
+        }
+        return lambda resource_type, **kwargs: tables[resource_type]
+
     def test_returns_resolved_summary(self, session, mock_client):
+        # REAL Taiga shape: priority/severity/type come back as bare integer IDs.
+        # Taiga publishes no priority_extra_info/severity_extra_info/type_extra_info
+        # (only assigned_to/owner/project/status), so the names must come from a
+        # reverse lookup against the project's attribute tables. Deliberately no
+        # *_extra_info keys here — an earlier fixture supplied them, which made this
+        # test pass against a payload Taiga never sends while production returned
+        # None for all three.
         mock_client.api.get.return_value = {"id": 1, "slug": "p", "name": "P"}
+        mock_client.list_resources.side_effect = self._attr_lists()
         mock_client.api.issues.get_by_ref.return_value = {
             "ref": 1212,
             "subject": "Bug",
             "status_extra_info": {"name": "New"},
-            "priority_extra_info": {"name": "High"},
-            "severity_extra_info": {"name": "Normal"},
-            "type_extra_info": {"name": "Bug"},
+            "priority": 27,
+            "severity": 45,
+            "type": 25,
             "assigned_to_extra_info": None,
             "is_closed": False,
         }
@@ -1809,8 +1827,51 @@ class TestGetIssue:
         assert result["status"] == "New"
         assert result["is_closed"] is False
         assert result["priority"] == "High"
+        assert result["severity"] == "Critical"
         assert result["type"] == "Bug"
         mock_client.api.issues.get_by_ref.assert_called_once_with(ref=1212, project=1)
+
+    def test_unknown_attribute_id_yields_none_not_crash(self, session, mock_client):
+        # An ID absent from the project's table (stale cache, cross-project ref)
+        # must degrade to None rather than raising.
+        mock_client.api.get.return_value = {"id": 1, "slug": "p", "name": "P"}
+        mock_client.list_resources.side_effect = self._attr_lists()
+        mock_client.api.issues.get_by_ref.return_value = {
+            "ref": 1213,
+            "subject": "Odd",
+            "status_extra_info": {"name": "New"},
+            "priority": 9999,
+            "severity": None,
+            "type": 25,
+        }
+        result = wf.get_issue("p", 1213, session_id=session)
+        assert result["priority"] is None
+        assert result["severity"] is None
+        assert result["type"] == "Bug"
+
+    def test_story_sprint_comes_from_flat_milestone_name(self):
+        # Taiga sends no milestone_extra_info on user stories — the sprint is the
+        # flat milestone_name (slug as fallback). Reading the phantom key returned
+        # None for every story that had a sprint.
+        assert (
+            wf._story_summary({"ref": 1, "milestone": 85, "milestone_name": "Sprint 9"})["sprint"]
+            == "Sprint 9"
+        )
+        assert (
+            wf._story_summary({"ref": 2, "milestone": 85, "milestone_slug": "sprint-9"})["sprint"]
+            == "sprint-9"
+        )
+        assert wf._story_summary({"ref": 3})["sprint"] is None
+
+    def test_summary_without_resolver_context_returns_raw_ids(self):
+        # _issue_summary is also reachable without client/project context. It must
+        # then surface the raw IDs, never a misleading None.
+        result = wf._issue_summary(
+            {"ref": 7, "subject": "s", "priority": 27, "severity": 45, "type": 25}
+        )
+        assert result["priority"] == 27
+        assert result["severity"] == 45
+        assert result["type"] == 25
 
     def test_raises_when_not_found(self, session, mock_client):
         mock_client.api.get.return_value = {"id": 1, "slug": "p", "name": "P"}
@@ -2058,9 +2119,13 @@ class TestGetProjectOverview:
 
         def lr(resource, **kw):
             return {
+                # REAL membership shape: no user_extra_info, no username. Identity
+                # is flat, and `email` is often blank while `user_email` is set.
                 "memberships": [
                     {
-                        "user_extra_info": {"username": "bob"},
+                        "user": 8,
+                        "user_email": "bob@example.com",
+                        "email": "",
                         "full_name": "Bob",
                         "role_name": "Dev",
                         "is_admin": False,
@@ -2089,7 +2154,10 @@ class TestGetProjectOverview:
         assert result["total_stories"] == 3
         assert result["stories_by_status"] == {"New": 2, "Done": 1}
         assert result["active_sprint"]["name"] == "S1"
-        assert result["team"][0]["username"] == "bob"
+        # Sourced from user_email, not the blank `email` and not a phantom
+        # user_extra_info.username (which Taiga never sends on memberships).
+        assert result["team"][0]["email"] == "bob@example.com"
+        assert result["team"][0]["full_name"] == "Bob"
 
     def test_no_active_sprint_when_none_cover_today(self, session, mock_client):
         mock_client.api.get.return_value = {"id": 1, "slug": "p", "name": "P"}

--- a/tests/test_server_workflow.py
+++ b/tests/test_server_workflow.py
@@ -1882,7 +1882,7 @@ class TestGetIssue:
         # All-or-nothing: a caller that passes client+project_id but forgets
         # session_id must not silently receive raw IDs that look resolved.
         with pytest.raises(ValueError, match="passed together"):
-            wf._issue_summary({"ref": 1}, client=object(), project_id=1)
+            wf._issue_summary({"ref": 1}, client=MagicMock(), project_id=1)
 
     def test_summary_without_resolver_context_returns_raw_ids(self):
         # _issue_summary is also reachable without client/project context. It must

--- a/tests/test_taiga_client.py
+++ b/tests/test_taiga_client.py
@@ -141,15 +141,38 @@ class TestResolveUserId:
     """Shared None-safe user resolver used by both server flavors (pytaiga-mcp#120)."""
 
     def _members(self):
+        """A REAL /memberships payload.
+
+        Membership rows carry no ``user_extra_info`` and no ``username`` field at
+        all, and the flat ``email`` is frequently blank on established members
+        while ``user_email`` holds the real address. The previous fixture supplied
+        ``user_extra_info``, so username/display-name tests passed against a
+        payload Taiga never sends while those code paths were dead in production.
+        """
         return [
             # pending-invite membership with null fields — must not abort matching
-            {"user": None, "email": None, "full_name": None, "user_extra_info": None},
+            {"user": None, "email": None, "user_email": None, "full_name": None},
             {
                 "user": 42,
-                "email": "alice@example.com",
+                "email": "",
+                "user_email": "alice@example.com",
                 "full_name": "Alice Martin",
-                "user_extra_info": {"username": "alice", "full_name_display": "Alice Martin"},
             },
+        ]
+
+    def _members_with_extra_info(self):
+        """A non-memberships payload that DOES carry ``user_extra_info``.
+
+        Only for the forward-compatibility lookups: ``resolve_user_id`` accepts
+        member lists from other endpoints, so it still probes
+        ``user_extra_info.username`` / ``.full_name_display``. Kept separate so it
+        is never mistaken for a memberships shape.
+        """
+        return [
+            {
+                "user": 7,
+                "user_extra_info": {"username": "carol", "full_name_display": "Carol Danvers"},
+            }
         ]
 
     def test_int_passes_through_without_lookup(self):
@@ -164,22 +187,39 @@ class TestResolveUserId:
         with pytest.raises(ValueError, match="Empty username"):
             resolve_user_id(self._members(), "")
 
-    def test_resolves_by_username_case_insensitive(self):
-        assert resolve_user_id(self._members(), "ALICE") == 42
-
-    def test_resolves_by_email(self):
+    def test_resolves_by_user_email_when_flat_email_is_blank(self):
+        # THE regression this fix exists for: on a real memberships row `email` is
+        # "" and the address lives in `user_email`. Matching only the flat `email`
+        # made assignment-by-email fail for every established member.
         assert resolve_user_id(self._members(), "alice@example.com") == 42
+
+    def test_resolves_by_user_email_case_insensitive(self):
+        assert resolve_user_id(self._members(), "ALICE@EXAMPLE.COM") == 42
+
+    def test_resolves_by_flat_email_when_populated(self):
+        # Some payloads do fill `email`; that path must keep working.
+        members = [{"user": 9, "email": "dave@example.com", "user_email": None}]
+        assert resolve_user_id(members, "dave@example.com") == 9
 
     def test_resolves_by_full_name(self):
         assert resolve_user_id(self._members(), "Alice Martin") == 42
 
-    def test_resolves_by_display_name(self):
+    def test_resolves_by_full_name_case_insensitive(self):
         assert resolve_user_id(self._members(), "alice martin") == 42
+
+    def test_resolves_by_username_on_non_memberships_payload(self):
+        # Forward-compat only — memberships never carry username. See
+        # _members_with_extra_info.
+        assert resolve_user_id(self._members_with_extra_info(), "CAROL") == 7
+
+    def test_resolves_by_display_name_on_non_memberships_payload(self):
+        # Forward-compat only — see above.
+        assert resolve_user_id(self._members_with_extra_info(), "carol danvers") == 7
 
     def test_null_field_member_does_not_crash(self):
         # The regression: the leading null-field member previously raised
         # "'NoneType' object has no attribute 'lower'" before reaching Alice.
-        assert resolve_user_id(self._members(), "alice") == 42
+        assert resolve_user_id(self._members(), "alice@example.com") == 42
 
     def test_skips_match_when_member_user_is_none(self):
         # A member matching by email but with user=None must not return None;
@@ -190,6 +230,17 @@ class TestResolveUserId:
 
     def test_raises_when_not_found(self):
         with pytest.raises(ValueError, match="not found"):
+            resolve_user_id(self._members(), "bob")
+
+    def test_not_found_error_falls_back_to_user_email_in_listing(self):
+        # A member whose only address is user_email must still be named in the
+        # diagnostic — it previously rendered "?" because only flat `email` was
+        # consulted, and that is blank on real rows.
+        with pytest.raises(ValueError, match="alice@example.com"):
+            resolve_user_id([{"user": 42, "email": "", "user_email": "alice@example.com"}], "bob")
+
+    def test_not_found_error_prefers_full_name_in_listing(self):
+        with pytest.raises(ValueError, match="Alice Martin"):
             resolve_user_id(self._members(), "bob")
 
 


### PR DESCRIPTION
## Problem

Taiga's serializers expose only `status`, `assigned_to`, `owner` and `project` `*_extra_info` objects (plus `user_story` on tasks). Three keys read across this codebase are **fictional**, so `(x.get("..._extra_info") or {}).get(...)` resolved to `None` on every single call — silently, because `.get()` on a missing key can't fail.

I audited every `*_extra_info` read. **Epics, tasks and milestones were clean**; three sites were not.

## What was broken

**1. Issues — `priority` / `severity` / `type` reported as `null`.**
The values were being **set correctly all along**; only the reported result was wrong, which made a correctly-populated field look unset. Verified on a live instance: issue `#1293` holds `priority=27` / `severity=45` / `type=25` while every tool reported `null`. This is the most misleading of the three — it inverts the diagnosis and invites re-setting a field that was already right.

**2. User stories — `sprint` was always `null`** for every story that had one, via `milestone_extra_info`. The sprint arrives as flat `milestone_name` / `milestone_slug`.

**3. Memberships — no `user_extra_info`, and no `username` field at all.** Identity is flat. Critically, `email` is frequently **blank** on established members while `user_email` is populated — so `resolve_user_id`'s email matching failed for exactly those members, falling through to a full-name match or a spurious "not found".

## Changes

- Added `_name_for_issue_attribute()` — reverse-maps priority/severity/type IDs to names off the **same session cache** `_resolve_issue_attribute` already populates, so it adds no API calls. Unknown IDs degrade to `None` rather than raising. Wired into `create_issue`, `update_issue` and `_issue_summary` (→ `get_issue`).
- `_issue_summary()` takes optional `client` / `project_id` / `session_id`. Without that context it returns the **raw IDs** rather than a misleading `None`.
- `_story_summary` and `create_story` read flat `milestone_name` / `milestone_slug`.
- `resolve_user_id` also matches `user_email` (and lists it in the not-found error). The dead `user_extra_info` lookups are retained for forward-compatibility with endpoints that do return them, and documented as never matching on a memberships payload.
- `get_project_overview` exposes `team[].email` instead of the permanently-null `team[].username`.
- Removed the three phantom keys from `server_full.py`'s issue response allowlist (dead config — it already emitted the raw IDs, so its output is unchanged).

## Why this survived

**The unit tests had encoded the bugs.** Their fixtures supplied the phantom keys, so they asserted against payloads Taiga never sends and stayed green while production returned `None`. Fixtures rewritten to the real shapes, plus regression cover for: unknown-ID fallback, the no-context `_issue_summary` path, and flat milestone resolution.

## Verification

- 546 unit tests pass; `ruff check` and `ruff format --check` clean under the pinned **0.16.0**.
- The 3 `tests/test_integration.py` errors are pre-existing and unrelated (they need live fixture credentials) — confirmed identical with these changes stashed.
- **Live Taiga:** issue `#1293` → `Bug` / `High` / `Critical`; story `#339` → `Sprint DeepMind Drive`; team rows carry real addresses; `resolve_user_id` resolves an email whose flat `email` field is blank.

## Reviewer note

`get_project_overview`'s `team[].username` is **renamed** to `team[].email`. The old key was unconditionally `null`, so no caller could have read a useful value from it — but it is a response-shape change, so `4f8a8cf` carries a `BREAKING CHANGE:` footer and semantic-release will cut a **major**. Drop the footer if that is not wanted.

### Review rounds

- **Round 1** (`4f8a8cf`) — purged 15 phantom fixtures across two files, exposing and fixing 3 false-confidence tests; added raw-ID fallback, an all-or-nothing context guard, and the previously-missing `user_email` coverage.
- **Round 2** (`cd1a9f4`) — ~11 tool descriptions still advertised assignment "by username", which cannot work since both resolvers read `/memberships` and memberships carry no username. Corrected to "email or full name".

