### PR TITLE
feat(server_full): resolve issue priority/severity/type names alongside the IDs

### DIFF
--- a/src/server_full.py
+++ b/src/server_full.py
@@ -389,6 +389,36 @@ active_sessions: Dict[str, TaigaClientWrapper] = {}
 # Reserved session ID for auto-authenticated session from environment variables
 DEFAULT_SESSION_ID = "default"
 
+# Per-(session, project) cache of issue attribute tables; see _issue_attr_tables.
+# Declared up here because _bind_session purges it, and binding happens during
+# import-time auto-authentication — before the issue helpers are defined.
+# {"<session_id>:<project_id>": {"priority": {id: name}, ...}}
+_issue_attr_cache: Dict[str, Dict[str, Dict[int, str]]] = {}
+
+
+def _purge_issue_attr_cache(session_id: str) -> None:
+    """Drop every cached attribute table for a session.
+
+    Keys are ``"<session_id>:<project_id>"``, so one session's entries span every
+    project it touched.
+    """
+    prefix = f"{session_id}:"
+    for key in [k for k in _issue_attr_cache if k.startswith(prefix)]:
+        del _issue_attr_cache[key]
+
+
+def _bind_session(session_id: str, wrapper: TaigaClientWrapper) -> None:
+    """Register an authenticated client under ``session_id``, clearing stale state.
+
+    Session ids are reusable — ``DEFAULT_SESSION_ID`` is the fixed string "default",
+    re-bound by auto-authentication and by ``login`` — so binding a new client to an
+    existing id must not leave the previous holder's cached project tables in place.
+    Every write into ``active_sessions`` goes through here so a future call site
+    cannot silently miss the purge.
+    """
+    _purge_issue_attr_cache(session_id)
+    active_sessions[session_id] = wrapper
+
 
 # --- Lifespan for Auto-Authentication ---
 @asynccontextmanager
@@ -405,7 +435,7 @@ async def server_lifespan(server: FastMCP) -> AsyncIterator[None]:
                 username=settings.get_username_value(), password=settings.get_password_value()
             )
             if success:
-                active_sessions[DEFAULT_SESSION_ID] = wrapper
+                _bind_session(DEFAULT_SESSION_ID, wrapper)
                 logger.info(
                     f"Auto-authentication successful. Default session created: '{DEFAULT_SESSION_ID}'"
                 )
@@ -695,7 +725,7 @@ def _get_item_by_ref(
             f"{item_label.capitalize()} with ref #{ref} not found in project {project_id}"
         )
     if item_type == "issue":
-        result = _annotate_issue_attr_names(result, actual_session_id)
+        result = _annotate_issue_attr_names(result, actual_session_id, verbosity)
     return _filter_response(result, item_type, verbosity)
 
 
@@ -713,10 +743,6 @@ _ISSUE_ATTR_RESOURCES = {
     "severity": "severities",
     "type": "issue_types",
 }
-
-# {"<session_id>:<project_id>": {"priority": {id: name}, ...}}. Cleared on logout so a
-# re-login cannot serve another user's project tables.
-_issue_attr_cache: Dict[str, Dict[str, Dict[int, str]]] = {}
 
 
 def _issue_attr_tables(
@@ -750,27 +776,20 @@ def _issue_attr_tables(
     return tables
 
 
-def _purge_issue_attr_cache(session_id: str) -> None:
-    """Drop every cached attribute table for a session (called on logout).
-
-    Keys are ``"<session_id>:<project_id>"``, so a session's entries span every project
-    it touched. Without this, a re-login reusing a session id could be served another
-    user's project tables.
-    """
-    prefix = f"{session_id}:"
-    for key in [k for k in _issue_attr_cache if k.startswith(prefix)]:
-        del _issue_attr_cache[key]
-
-
-def _annotate_issue_attr_names(response, session_id: str):
+def _annotate_issue_attr_names(response, session_id: str, verbosity: str = "standard"):
     """Add priority_name / severity_name / type_name beside the raw integer IDs.
 
     Accepts a single issue dict or a list of them, and mutates in place (the dicts come
     straight from the API layer). Issues without a ``project`` are skipped — the project
     is what scopes the attribute tables. Must run BEFORE ``_filter_response``, and the
     added keys are allow-listed in ``RESPONSE_FIELDS['issue']['standard']``.
+
+    Skipped entirely at ``verbosity='minimal'``: that tier filters the ``*_name`` keys
+    straight back out, so resolving them would spend three API calls per project on data
+    guaranteed to be discarded. Any other value (including an invalid one, which
+    ``_filter_response`` normalises to 'standard') still resolves.
     """
-    if response is None:
+    if response is None or verbosity == "minimal":
         return response
     items = response if isinstance(response, list) else [response]
     client: Optional[TaigaClientWrapper] = None
@@ -859,10 +878,10 @@ def login(
             # Generate a unique session ID
             new_session_id = str(uuid.uuid4())
             # Store the authenticated wrapper in our manual session store
-            active_sessions[new_session_id] = wrapper
+            _bind_session(new_session_id, wrapper)
             # Set as default session if none exists yet
             if DEFAULT_SESSION_ID not in active_sessions:
-                active_sessions[DEFAULT_SESSION_ID] = wrapper
+                _bind_session(DEFAULT_SESSION_ID, wrapper)
                 logger.info(
                     f"Login successful. Session created and set as default: '{DEFAULT_SESSION_ID}'"
                 )
@@ -1739,7 +1758,7 @@ def list_issues(
         ),
         f"project {project_id}",
     )
-    result = _annotate_issue_attr_names(result, actual_session_id)
+    result = _annotate_issue_attr_names(result, actual_session_id, verbosity)
     return _filter_response(result, "issue", verbosity)
 
 
@@ -1790,7 +1809,7 @@ def create_issue(
         ),
         f"issue '{subject}'",
     )
-    result = _annotate_issue_attr_names(result, actual_session_id)
+    result = _annotate_issue_attr_names(result, actual_session_id, verbosity)
     return _filter_response(result, "issue", verbosity)
 
 
@@ -1811,7 +1830,7 @@ def get_issue(
         lambda: taiga_client_wrapper.api.issues.get(issue_id),
         f"issue {issue_id}",
     )
-    result = _annotate_issue_attr_names(result, actual_session_id)
+    result = _annotate_issue_attr_names(result, actual_session_id, verbosity)
     return _filter_response(result, "issue", verbosity)
 
 
@@ -1868,7 +1887,7 @@ def update_issue(
             issue_id=issue_id, version=version, data=parsed_kwargs
         )
         logger.info(f"Issue {issue_id} update request sent.")
-        updated_issue = _annotate_issue_attr_names(updated_issue, actual_session_id)
+        updated_issue = _annotate_issue_attr_names(updated_issue, actual_session_id, verbosity)
         return _filter_response(updated_issue, "issue", verbosity)
     except TaigaException as e:
         logger.error(f"Taiga API error updating issue {issue_id}: {e}", exc_info=False)
@@ -3633,8 +3652,10 @@ def session_status(session_id: Optional[str] = None) -> Dict[str, Any]:
             logger.warning(
                 f"Session {actual_session_id[:8]} found but token seems invalid (API check failed)."
             )
-            # Clean up invalid session
+            # Clean up invalid session (and its cached per-project state, or a
+            # re-bind of this id would be served these tables).
             active_sessions.pop(actual_session_id, None)
+            _purge_issue_attr_cache(actual_session_id)
             return {
                 "status": "inactive",
                 "reason": "token_invalid",
@@ -4143,7 +4164,7 @@ def bulk_create_issues(
     result = _execute_taiga_operation(
         "bulk_create_issues", do_bulk, f"{len(cleaned)} issues in project {project_id}"
     )
-    result = _annotate_issue_attr_names(result, actual_session_id)
+    result = _annotate_issue_attr_names(result, actual_session_id, verbosity)
     return _filter_response(result, "issue", verbosity)
 
 

--- a/src/server_full.py
+++ b/src/server_full.py
@@ -265,10 +265,15 @@ RESPONSE_FIELDS: Dict[str, Dict[str, Optional[List[str]]]] = {
             "status_extra_info",
             # priority/severity/type are bare integer IDs. Taiga publishes no
             # *_extra_info for them (only assigned_to/owner/project/status), so
-            # listing those keys here would be dead config.
+            # listing those keys here would be dead config. The `*_name`
+            # companions are injected by _annotate_issue_attr_names before
+            # filtering; 'minimal' deliberately keeps only the raw IDs.
             "priority",
+            "priority_name",
             "severity",
+            "severity_name",
             "type",
+            "type_name",
             "assigned_to",
             "assigned_to_extra_info",
             "milestone",
@@ -689,7 +694,100 @@ def _get_item_by_ref(
         raise ValueError(
             f"{item_label.capitalize()} with ref #{ref} not found in project {project_id}"
         )
+    if item_type == "issue":
+        result = _annotate_issue_attr_names(result, actual_session_id)
     return _filter_response(result, item_type, verbosity)
+
+
+# --- Issue attribute name resolution ---
+#
+# Taiga publishes no priority_extra_info / severity_extra_info / type_extra_info on its
+# issue serializer (only assigned_to / owner / project / status), so those three fields
+# arrive as bare integer IDs. Workflow mode reverse-maps them to names; full mode is a
+# deliberate 1:1 mapping of the REST API, so the raw IDs stay put and we ADD `*_name`
+# companions rather than replacing them. That keeps existing callers working while making
+# a response like `"priority": 27` interpretable without three extra tool calls.
+
+_ISSUE_ATTR_RESOURCES = {
+    "priority": "priorities",
+    "severity": "severities",
+    "type": "issue_types",
+}
+
+# {"<session_id>:<project_id>": {"priority": {id: name}, ...}}. Cleared on logout so a
+# re-login cannot serve another user's project tables.
+_issue_attr_cache: Dict[str, Dict[str, Dict[int, str]]] = {}
+
+
+def _issue_attr_tables(
+    client: TaigaClientWrapper, project_id: int, session_id: str
+) -> Dict[str, Dict[int, str]]:
+    """Return {attr: {id: name}} for a project's priorities/severities/issue types.
+
+    Cached per (session, project): without this, annotating a list of issues would cost
+    three extra API calls per issue. Fetch failures degrade to an empty table so a read
+    still succeeds with the raw IDs rather than failing outright.
+    """
+    key = f"{session_id}:{project_id}"
+    tables = _issue_attr_cache.get(key)
+    if tables is None:
+        tables = {}
+        for attr, resource in _ISSUE_ATTR_RESOURCES.items():
+            try:
+                items = client.list_resources(resource, project_id=project_id)
+            except Exception as exc:  # noqa: BLE001 — name lookup is best-effort
+                logger.warning(
+                    f"Could not load {resource} for project {project_id}; "
+                    f"issue {attr} names unavailable: {exc}"
+                )
+                items = []
+            tables[attr] = {
+                i["id"]: i.get("name")
+                for i in items
+                if isinstance(i, dict) and i.get("id") is not None
+            }
+        _issue_attr_cache[key] = tables
+    return tables
+
+
+def _purge_issue_attr_cache(session_id: str) -> None:
+    """Drop every cached attribute table for a session (called on logout).
+
+    Keys are ``"<session_id>:<project_id>"``, so a session's entries span every project
+    it touched. Without this, a re-login reusing a session id could be served another
+    user's project tables.
+    """
+    prefix = f"{session_id}:"
+    for key in [k for k in _issue_attr_cache if k.startswith(prefix)]:
+        del _issue_attr_cache[key]
+
+
+def _annotate_issue_attr_names(response, session_id: str):
+    """Add priority_name / severity_name / type_name beside the raw integer IDs.
+
+    Accepts a single issue dict or a list of them, and mutates in place (the dicts come
+    straight from the API layer). Issues without a ``project`` are skipped — the project
+    is what scopes the attribute tables. Must run BEFORE ``_filter_response``, and the
+    added keys are allow-listed in ``RESPONSE_FIELDS['issue']['standard']``.
+    """
+    if response is None:
+        return response
+    items = response if isinstance(response, list) else [response]
+    client: Optional[TaigaClientWrapper] = None
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        project_id = item.get("project")
+        if project_id is None:
+            continue
+        if client is None:
+            client = _get_authenticated_client(session_id)
+        tables = _issue_attr_tables(client, project_id, session_id)
+        for attr in _ISSUE_ATTR_RESOURCES:
+            attr_id = item.get(attr)
+            if attr_id is not None:
+                item[f"{attr}_name"] = tables.get(attr, {}).get(attr_id)
+    return response
 
 
 # --- MCP Tools ---
@@ -1618,7 +1716,7 @@ def get_task_statuses(project_id: int, session_id: Optional[str] = None) -> List
 
 @mcp.tool(
     "list_issues",
-    description="Lists issues within a specific project, optionally filtered. Results include both 'id' (internal, use for get/update/delete) and 'ref' (human-readable '#N' shown in Taiga UI). verbosity: 'minimal' (id/ref/subject/status/priority/severity/project), 'standard' (default), 'full'. Uses default session if session_id not provided.",
+    description="Lists issues within a specific project, optionally filtered. Results include both 'id' (internal, use for get/update/delete) and 'ref' (human-readable '#N' shown in Taiga UI). verbosity: 'minimal' (id/ref/subject/status/priority/severity/project), 'standard' (default), 'full'. At 'standard' and 'full' verbosity the response also carries priority_name / severity_name / type_name resolved from those integer IDs (Taiga sends no *_extra_info for them); 'minimal' returns the raw IDs only. Uses default session if session_id not provided.",
 )
 def list_issues(
     project_id: int,
@@ -1641,6 +1739,7 @@ def list_issues(
         ),
         f"project {project_id}",
     )
+    result = _annotate_issue_attr_names(result, actual_session_id)
     return _filter_response(result, "issue", verbosity)
 
 
@@ -1691,12 +1790,13 @@ def create_issue(
         ),
         f"issue '{subject}'",
     )
+    result = _annotate_issue_attr_names(result, actual_session_id)
     return _filter_response(result, "issue", verbosity)
 
 
 @mcp.tool(
     "get_issue",
-    description="Gets detailed information about a specific issue by its internal ID (not the ref number shown in Taiga UI). Use get_issue_by_ref if you have the '#N' reference number instead. verbosity: 'minimal', 'standard' (default), 'full'. Uses default session if session_id not provided.",
+    description="Gets detailed information about a specific issue by its internal ID (not the ref number shown in Taiga UI). Use get_issue_by_ref if you have the '#N' reference number instead. verbosity: 'minimal', 'standard' (default), 'full'. At 'standard' and 'full' verbosity the response also carries priority_name / severity_name / type_name resolved from those integer IDs (Taiga sends no *_extra_info for them); 'minimal' returns the raw IDs only. Uses default session if session_id not provided.",
 )
 def get_issue(
     issue_id: int, session_id: Optional[str] = None, verbosity: str = "standard"
@@ -1711,12 +1811,13 @@ def get_issue(
         lambda: taiga_client_wrapper.api.issues.get(issue_id),
         f"issue {issue_id}",
     )
+    result = _annotate_issue_attr_names(result, actual_session_id)
     return _filter_response(result, "issue", verbosity)
 
 
 @mcp.tool(
     "get_issue_by_ref",
-    description="Gets an issue by its human-readable reference number (the '#N' shown in Taiga UI). Requires the project_id. Use this instead of get_issue when you have a ref number. verbosity: 'minimal', 'standard' (default), 'full'. Uses default session if session_id not provided.",
+    description="Gets an issue by its human-readable reference number (the '#N' shown in Taiga UI). Requires the project_id. Use this instead of get_issue when you have a ref number. verbosity: 'minimal', 'standard' (default), 'full'. At 'standard' and 'full' verbosity the response also carries priority_name / severity_name / type_name resolved from those integer IDs (Taiga sends no *_extra_info for them); 'minimal' returns the raw IDs only. Uses default session if session_id not provided.",
 )
 def get_issue_by_ref(
     project_id: int, ref: int, session_id: Optional[str] = None, verbosity: str = "standard"
@@ -1767,6 +1868,7 @@ def update_issue(
             issue_id=issue_id, version=version, data=parsed_kwargs
         )
         logger.info(f"Issue {issue_id} update request sent.")
+        updated_issue = _annotate_issue_attr_names(updated_issue, actual_session_id)
         return _filter_response(updated_issue, "issue", verbosity)
     except TaigaException as e:
         logger.error(f"Taiga API error updating issue {issue_id}: {e}", exc_info=False)
@@ -3500,6 +3602,7 @@ def logout(session_id: Optional[str] = None) -> Dict[str, Any]:
     logger.info(f"Executing logout for session {actual_session_id[:8]}...")
     # Remove from dict, return None if not found
     client_wrapper = active_sessions.pop(actual_session_id, None)
+    _purge_issue_attr_cache(actual_session_id)
     if client_wrapper:
         logger.info(f"Session {actual_session_id[:8]} logged out successfully.")
         # No specific API logout call needed usually for token-based auth
@@ -4040,6 +4143,7 @@ def bulk_create_issues(
     result = _execute_taiga_operation(
         "bulk_create_issues", do_bulk, f"{len(cleaned)} issues in project {project_id}"
     )
+    result = _annotate_issue_attr_names(result, actual_session_id)
     return _filter_response(result, "issue", verbosity)
 
 

--- a/src/server_full.py
+++ b/src/server_full.py
@@ -413,11 +413,26 @@ def _bind_session(session_id: str, wrapper: TaigaClientWrapper) -> None:
     Session ids are reusable — ``DEFAULT_SESSION_ID`` is the fixed string "default",
     re-bound by auto-authentication and by ``login`` — so binding a new client to an
     existing id must not leave the previous holder's cached project tables in place.
-    Every write into ``active_sessions`` goes through here so a future call site
-    cannot silently miss the purge.
+
+    This and the two ``_unbind_*`` helpers are the ONLY places that mutate
+    ``active_sessions``. Routing every mutation through them keeps "a session and its
+    cached tables move together" true by construction rather than by argument — the
+    first attempt patched individual call sites and missed one.
     """
     _purge_issue_attr_cache(session_id)
     active_sessions[session_id] = wrapper
+
+
+def _unbind_session(session_id: str) -> Optional[TaigaClientWrapper]:
+    """Remove one session and its cached per-project state; return its client, if any."""
+    _purge_issue_attr_cache(session_id)
+    return active_sessions.pop(session_id, None)
+
+
+def _unbind_all_sessions() -> None:
+    """Drop every session and all cached per-project state (server shutdown)."""
+    active_sessions.clear()
+    _issue_attr_cache.clear()
 
 
 # --- Lifespan for Auto-Authentication ---
@@ -452,7 +467,7 @@ async def server_lifespan(server: FastMCP) -> AsyncIterator[None]:
     finally:
         # Cleanup on shutdown
         logger.info("Server shutting down. Cleaning up sessions...")
-        active_sessions.clear()
+        _unbind_all_sessions()
 
 
 # --- MCP Server Definition ---
@@ -3620,8 +3635,7 @@ def logout(session_id: Optional[str] = None) -> Dict[str, Any]:
     actual_session_id = _get_session_id(session_id)
     logger.info(f"Executing logout for session {actual_session_id[:8]}...")
     # Remove from dict, return None if not found
-    client_wrapper = active_sessions.pop(actual_session_id, None)
-    _purge_issue_attr_cache(actual_session_id)
+    client_wrapper = _unbind_session(actual_session_id)
     if client_wrapper:
         logger.info(f"Session {actual_session_id[:8]} logged out successfully.")
         # No specific API logout call needed usually for token-based auth
@@ -3654,8 +3668,7 @@ def session_status(session_id: Optional[str] = None) -> Dict[str, Any]:
             )
             # Clean up invalid session (and its cached per-project state, or a
             # re-bind of this id would be served these tables).
-            active_sessions.pop(actual_session_id, None)
-            _purge_issue_attr_cache(actual_session_id)
+            _unbind_session(actual_session_id)
             return {
                 "status": "inactive",
                 "reason": "token_invalid",

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4,6 +4,7 @@ import uuid
 from unittest.mock import MagicMock, patch
 
 import pytest
+from pytaigaclient.exceptions import TaigaException
 
 # Import the server module instead of specific functions
 import src.server_full as src_server
@@ -1061,6 +1062,20 @@ class TestTaigaTools:
         result = src_server.get_issue(100, session_id, verbosity="minimal")
         assert result["priority"] == 3
         assert "priority_name" not in result
+        # And it must not PAY for names it discards: 'minimal' filters the *_name
+        # keys straight back out, so resolving them would burn three API calls per
+        # project on data guaranteed to be dropped. Asserting absence alone let
+        # that waste hide.
+        assert mock_client.list_resources.call_count == 0
+
+    def test_invalid_verbosity_still_resolves_names(self, session_setup):
+        # _filter_response normalises an unknown verbosity to 'standard', so the
+        # skip must key on the exact string 'minimal' and nothing else.
+        session_id, mock_client = session_setup
+        mock_client.api.issues.get.return_value = self._issue()
+        mock_client.list_resources.side_effect = self._attr_tables()
+        result = src_server.get_issue(100, session_id, verbosity="nonsense")
+        assert result["priority_name"] == "High"
 
     def test_unknown_id_and_lookup_failure_degrade_gracefully(self, session_setup):
         session_id, mock_client = session_setup
@@ -1075,14 +1090,61 @@ class TestTaigaTools:
         assert result["priority"] == 999  # raw ID still returned
         assert result["priority_name"] is None
 
-    def test_logout_purges_attribute_cache(self, session_setup):
-        session_id, mock_client = session_setup
+    def _cached_keys(self, session_id):
+        return [k for k in src_server._issue_attr_cache if k.startswith(f"{session_id}:")]
+
+    def _populate_cache(self, session_id, mock_client):
         mock_client.api.issues.get.return_value = self._issue()
         mock_client.list_resources.side_effect = self._attr_tables()
         src_server.get_issue(100, session_id)
-        assert any(k.startswith(f"{session_id}:") for k in src_server._issue_attr_cache)
+        assert self._cached_keys(session_id), "cache should be populated"
+
+    # Three paths replace or evict a session's client. Every one must clear the
+    # cached per-project tables, because session ids are REUSABLE —
+    # DEFAULT_SESSION_ID is the fixed string "default" — so a re-bind would
+    # otherwise serve the previous holder's tables. Covering only logout is how
+    # the original leak survived.
+
+    def test_logout_purges_attribute_cache(self, session_setup):
+        session_id, mock_client = session_setup
+        self._populate_cache(session_id, mock_client)
         src_server.logout(session_id)
-        assert not any(k.startswith(f"{session_id}:") for k in src_server._issue_attr_cache)
+        assert not self._cached_keys(session_id)
+
+    def test_invalid_token_eviction_purges_attribute_cache(self, session_setup):
+        session_id, mock_client = session_setup
+        self._populate_cache(session_id, mock_client)
+        mock_client.api.users.get_me.side_effect = TaigaException("token invalid")
+        assert src_server.session_status(session_id)["status"] == "inactive"
+        assert not self._cached_keys(session_id)
+
+    def test_rebinding_a_session_id_purges_the_previous_holders_cache(self):
+        # Regression for the proven leak: user A populates the fixed "default"
+        # session, A's client is evicted, user B re-binds the same id — B must not
+        # be served A's table.
+        sid = src_server.DEFAULT_SESSION_ID
+        a = MagicMock()
+        a.is_authenticated = True
+        src_server._bind_session(sid, a)
+        try:
+            a.api.issues.get.return_value = self._issue()
+            a.list_resources.side_effect = lambda r, **k: (
+                [{"id": 3, "name": "A-ONLY"}] if r == "priorities" else []
+            )
+            assert src_server.get_issue(100, sid)["priority_name"] == "A-ONLY"
+
+            b = MagicMock()
+            b.is_authenticated = True
+            src_server._bind_session(sid, b)  # same id, different client
+            b.api.issues.get.return_value = self._issue()
+            b.list_resources.side_effect = lambda r, **k: (
+                [{"id": 3, "name": "B-OWN"}] if r == "priorities" else []
+            )
+            assert src_server.get_issue(100, sid)["priority_name"] == "B-OWN"
+            assert b.list_resources.call_count > 0, "B must query its own tables"
+        finally:
+            src_server.active_sessions.pop(sid, None)
+            src_server._purge_issue_attr_cache(sid)
 
     def test_issue_without_project_is_left_alone(self, session_setup):
         session_id, mock_client = session_setup

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -993,6 +993,107 @@ class TestTaigaTools:
         assert result["id"] == 100
         mock_client.api.issues.get.assert_called_once_with(100)
 
+    # ─── Issue priority/severity/type name resolution ─────────────────
+    #
+    # Taiga sends these three as bare integer IDs with no *_extra_info, so full
+    # mode adds `*_name` companions beside the IDs (it stays a 1:1 API mapping,
+    # so the IDs are not replaced).
+
+    @staticmethod
+    def _attr_tables():
+        tables = {
+            "priorities": [{"id": 1, "name": "Low"}, {"id": 3, "name": "High"}],
+            "severities": [{"id": 2, "name": "Normal"}, {"id": 5, "name": "Critical"}],
+            "issue_types": [{"id": 7, "name": "Bug"}],
+        }
+        return lambda resource, **kw: tables.get(resource, [])
+
+    @staticmethod
+    def _issue(**over):
+        base = {
+            "id": 100,
+            "ref": 10,
+            "subject": "Bug",
+            "status": 1,
+            "priority": 3,
+            "severity": 5,
+            "type": 7,
+            "project": 123,
+            "version": 1,
+        }
+        base.update(over)
+        return base
+
+    def test_get_issue_adds_resolved_attribute_names(self, session_setup):
+        session_id, mock_client = session_setup
+        mock_client.api.issues.get.return_value = self._issue()
+        mock_client.list_resources.side_effect = self._attr_tables()
+        result = src_server.get_issue(100, session_id)
+        # Raw IDs preserved (1:1 mapping) AND names added beside them.
+        assert result["priority"] == 3 and result["priority_name"] == "High"
+        assert result["severity"] == 5 and result["severity_name"] == "Critical"
+        assert result["type"] == 7 and result["type_name"] == "Bug"
+
+    def test_attribute_tables_are_cached_per_session_and_project(self, session_setup):
+        session_id, mock_client = session_setup
+        mock_client.api.issues.get.return_value = self._issue()
+        mock_client.list_resources.side_effect = self._attr_tables()
+        src_server.get_issue(100, session_id)
+        src_server.get_issue(100, session_id)
+        # Three tables fetched once, not once per read — otherwise annotating a
+        # list of issues would cost three extra calls each.
+        assert mock_client.list_resources.call_count == 3
+
+    def test_list_issues_annotates_every_item(self, session_setup):
+        session_id, mock_client = session_setup
+        mock_client.list_resources.side_effect = lambda resource, **kw: (
+            [self._issue(id=1, priority=1), self._issue(id=2, priority=3)]
+            if resource == "issues"
+            else self._attr_tables()(resource, **kw)
+        )
+        result = src_server.list_issues(123, session_id=session_id)
+        assert [r["priority_name"] for r in result] == ["Low", "High"]
+
+    def test_minimal_verbosity_keeps_raw_ids_only(self, session_setup):
+        session_id, mock_client = session_setup
+        mock_client.api.issues.get.return_value = self._issue()
+        mock_client.list_resources.side_effect = self._attr_tables()
+        result = src_server.get_issue(100, session_id, verbosity="minimal")
+        assert result["priority"] == 3
+        assert "priority_name" not in result
+
+    def test_unknown_id_and_lookup_failure_degrade_gracefully(self, session_setup):
+        session_id, mock_client = session_setup
+        # 999 is absent from the table; and a failing lookup must not fail the read.
+        mock_client.api.issues.get.return_value = self._issue(priority=999)
+        mock_client.list_resources.side_effect = self._attr_tables()
+        assert src_server.get_issue(100, session_id)["priority_name"] is None
+
+        src_server._purge_issue_attr_cache(session_id)
+        mock_client.list_resources.side_effect = RuntimeError("boom")
+        result = src_server.get_issue(100, session_id)
+        assert result["priority"] == 999  # raw ID still returned
+        assert result["priority_name"] is None
+
+    def test_logout_purges_attribute_cache(self, session_setup):
+        session_id, mock_client = session_setup
+        mock_client.api.issues.get.return_value = self._issue()
+        mock_client.list_resources.side_effect = self._attr_tables()
+        src_server.get_issue(100, session_id)
+        assert any(k.startswith(f"{session_id}:") for k in src_server._issue_attr_cache)
+        src_server.logout(session_id)
+        assert not any(k.startswith(f"{session_id}:") for k in src_server._issue_attr_cache)
+
+    def test_issue_without_project_is_left_alone(self, session_setup):
+        session_id, mock_client = session_setup
+        # The project scopes the attribute tables; without it there is nothing to
+        # resolve against, and the read must still succeed.
+        mock_client.api.issues.get.return_value = self._issue(project=None)
+        mock_client.list_resources.side_effect = self._attr_tables()
+        result = src_server.get_issue(100, session_id)
+        assert "priority_name" not in result
+        mock_client.list_resources.assert_not_called()
+
     def test_get_issue_by_ref(self, session_setup):
         """Test get_issue_by_ref returns issue by ref number."""
         session_id, mock_client = session_setup

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1118,6 +1118,40 @@ class TestTaigaTools:
         assert src_server.session_status(session_id)["status"] == "inactive"
         assert not self._cached_keys(session_id)
 
+    def test_shutdown_clear_also_drops_all_cached_tables(self, session_setup):
+        # The lifespan shutdown clears every session; the cache must go with it, or
+        # sessions and their tables fall out of lockstep. Not reachable as a leak
+        # (a rebind is required to get back in, and that purges) but the invariant
+        # should hold by construction.
+        session_id, mock_client = session_setup
+        self._populate_cache(session_id, mock_client)
+        src_server._unbind_all_sessions()
+        assert src_server._issue_attr_cache == {}
+        assert src_server.active_sessions == {}
+
+    def test_only_the_session_helpers_mutate_active_sessions(self):
+        """Structural guard: every active_sessions mutation stays in the 3 helpers.
+
+        The first fix for the cache leak patched individual call sites and missed
+        one (the shutdown clear). This asserts the chokepoint holds, so a new call
+        site cannot reintroduce the class of bug.
+        """
+        import inspect
+        import re
+
+        source = inspect.getsource(src_server)
+        allowed = {"_bind_session", "_unbind_session", "_unbind_all_sessions"}
+        offenders = []
+        current = None
+        for line in source.splitlines():
+            func = re.match(r"def (\w+)", line)
+            if func:
+                current = func.group(1)
+            if re.search(r"active_sessions\s*\[[^\]]+\]\s*=|active_sessions\.(pop|clear)\(", line):
+                if current not in allowed:
+                    offenders.append(f"{current}: {line.strip()}")
+        assert not offenders, "active_sessions mutated outside the helpers: " + "; ".join(offenders)
+
     def test_rebinding_a_session_id_purges_the_previous_holders_cache(self):
         # Regression for the proven leak: user A populates the fixed "default"
         # session, A's client is evicted, user B re-binds the same id — B must not


### PR DESCRIPTION
Discharges the follow-up deliberately deferred from #129 (review finding #7).

## Problem

Taiga publishes no `priority_extra_info` / `severity_extra_info` / `type_extra_info` on its issue serializer, so those three fields arrive as **bare integer IDs**. #129 fixed workflow mode to reverse-map them, but **full mode still returns `"priority": 27`** with no way to interpret it short of three extra tool calls (`get_issue_priorities`, `…_severities`, `…_types`).

The same "misleading output" argument that justified #129 applies here — it was split out only to keep that PR reviewable.

## Approach: additive, not a replacement

`server_full.py` is a **deliberate 1:1 mapping of the REST API** (see CLAUDE.md). Replacing the IDs with names would break callers and defeat the mode's purpose. So this **adds** `priority_name` / `severity_name` / `type_name` beside the raw IDs — non-breaking, and the raw values stay available.

```
"priority": 27,  "priority_name": "High",
"severity": 45,  "severity_name": "Critical",
"type": 25,      "type_name": "Bug",
```

## Changes

- **`_issue_attr_tables()`** — fetches a project's priorities/severities/issue_types and caches them **per (session, project)**. Without the cache, annotating a list of issues would cost three extra API calls *per issue*. A fetch failure degrades to an empty table, so a read still succeeds with raw IDs rather than failing outright.
- **`_annotate_issue_attr_names()`** — handles a single issue or a list, and runs **before `_filter_response`** so the new keys pass the verbosity allowlist. Issues with no `project` are skipped (the project is what scopes the tables) and cost no lookup.
- **`_purge_issue_attr_cache()`** — called from `logout`, so a re-login reusing a session id can never be served another user's project tables.
- Wired into **all six** issue paths: `get_issue`, `get_issue_by_ref` (via `_get_item_by_ref`), `list_issues`, `create_issue`, `update_issue`, `bulk_create_issues`.
- **`minimal` verbosity deliberately keeps the raw IDs only**, matching its documented field list; names appear at `standard` and `full`. The three issue-read tool descriptions now state this.

## Tests — 7 new

Name resolution · per-(session, project) caching (asserts **3** lookups across two reads, not 6) · list annotation · minimal-verbosity exclusion · unknown-ID **and** lookup-failure degradation · logout purging · project-less issues short-circuiting.

Note the existing `test_get_issue` passed both before and after this change without exercising it — a bare `MagicMock` iterates empty, so the annotation silently no-ops. That's the same false-confidence trap #129 was about, hence the explicit fixtures here.

## Verification

- **562 tests** pass (was 555); `ruff check` + `format --check` clean under the pinned 0.16.0.
- 3 `tests/test_integration.py` errors remain pre-existing and unrelated (they need live fixture credentials).
- **Live Taiga:** `get_issue_by_ref(9, 1293)` → `priority 27/"High"`, `severity 45/"Critical"`, `type 25/"Bug"`; `verbosity="minimal"` returns IDs only.

## Reviewer notes

- Typed `feat:` rather than `fix:` — it adds response fields rather than correcting wrong ones. Cuts a **minor**, not a major.
- `_annotate_issue_attr_names` mutates the response dicts in place. They come straight from the API layer and are not shared, so this is safe and avoids copying whole issue lists — flagging it as a deliberate choice.
- The cache is module-level and keyed by session id. It is purged on logout, but a process that never logs out retains tables for the lifetime of the session. Project attribute tables change rarely; if that becomes a concern a TTL would be the next step.