### PR TITLE
fix(upsert_wiki): create path was unreachable — /wiki/by_slug raises 404

### DIFF
--- a/src/server_workflow.py
+++ b/src/server_workflow.py
@@ -20,7 +20,7 @@ from datetime import date
 from typing import Any, AsyncIterator, Dict, List, Optional, Union
 
 from mcp.server.fastmcp import FastMCP
-from pytaigaclient.exceptions import TaigaAPIError, TaigaException
+from pytaigaclient.exceptions import TaigaAPIError, TaigaException, TaigaNotFoundError
 
 from src.config import settings
 from src.taiga_client import TaigaClientWrapper, resolve_user_id, safe_lower
@@ -2192,7 +2192,15 @@ def upsert_wiki(
         proj = _resolve_project(client, project)
         project_id = proj["id"]
 
-        existing = client.api.get("/wiki/by_slug", params={"slug": slug, "project": project_id})
+        # `/wiki/by_slug` RAISES 404 for an unknown slug — it does not return a falsy
+        # value. Without this guard the exception escaped do_upsert and the `else`
+        # branch below was unreachable, so upsert_wiki could only ever UPDATE an
+        # existing page and never create one, despite its description. Catch the
+        # not-found case specifically so a 500 / auth failure still surfaces.
+        try:
+            existing = client.api.get("/wiki/by_slug", params={"slug": slug, "project": project_id})
+        except TaigaNotFoundError:
+            existing = None
         if existing:
             result = client.api.wiki.edit(
                 existing["id"], version=existing["version"], data={"slug": slug, "content": content}

--- a/tests/test_server_workflow.py
+++ b/tests/test_server_workflow.py
@@ -5,7 +5,12 @@ import uuid
 from unittest.mock import MagicMock
 
 import pytest
-from pytaigaclient.exceptions import TaigaAPIError, TaigaException
+from pytaigaclient.exceptions import (
+    TaigaAPIError,
+    TaigaException,
+    TaigaNotFoundError,
+    TaigaServerError,
+)
 
 import src.server_workflow as wf
 
@@ -519,16 +524,44 @@ class TestGetSprintBoard:
         assert len(result["stories"][0]["tasks"]) == 1
 
 
+def _api_error(exc_cls, status_code: int, message: str = "boom"):
+    """Build a real pytaigaclient API exception.
+
+    TaigaAPIError.__init__ takes (status_code, requests.Response) and reads
+    `_error_message` off the JSON body, so the exception cannot be constructed from a
+    bare string.
+    """
+    response = MagicMock()
+    response.json.return_value = {"_error_message": message}
+    response.text = message
+    return exc_cls(status_code, response)
+
+
 class TestUpsertWiki:
     def test_creates_new_page_when_not_found(self, session, mock_client):
-        # project resolution
+        # REAL behaviour: /wiki/by_slug RAISES 404 for an unknown slug, it does not
+        # return None. The previous fixture returned None, so this test passed while
+        # the create path was unreachable in production — the 404 escaped before the
+        # else branch. Modelling the raise is what makes this a real regression test.
         mock_client.api.get.side_effect = [
             {"id": 1, "slug": "p", "name": "P"},  # _resolve_project
-            None,  # /wiki/by_slug → not found
+            _api_error(TaigaNotFoundError, 404, "wiki page not found"),  # /wiki/by_slug
         ]
         mock_client.api.wiki.create.return_value = {"id": 9, "slug": "my-page"}
         result = wf.upsert_wiki("p", "my-page", "Content here", session_id=session)
         assert result["status"] == "created"
+        assert mock_client.api.wiki.create.call_args.kwargs["slug"] == "my-page"
+
+    def test_non_404_lookup_error_propagates(self, session, mock_client):
+        # The guard must be narrow: a server or auth failure on the lookup is not
+        # "page does not exist" and must not silently create a duplicate page.
+        mock_client.api.get.side_effect = [
+            {"id": 1, "slug": "p", "name": "P"},
+            _api_error(TaigaServerError, 500, "upstream exploded"),
+        ]
+        with pytest.raises(Exception):
+            wf.upsert_wiki("p", "my-page", "Content here", session_id=session)
+        mock_client.api.wiki.create.assert_not_called()
 
     def test_updates_existing_page(self, session, mock_client):
         mock_client.api.get.side_effect = [

--- a/tests/test_server_workflow.py
+++ b/tests/test_server_workflow.py
@@ -555,11 +555,14 @@ class TestUpsertWiki:
     def test_non_404_lookup_error_propagates(self, session, mock_client):
         # The guard must be narrow: a server or auth failure on the lookup is not
         # "page does not exist" and must not silently create a duplicate page.
+        # Asserting the exact type matters — _execute_taiga_operation re-raises
+        # TaigaAPIError unchanged, so a bare `raises(Exception)` would also pass if the
+        # call blew up for an unrelated reason, which is not what this test claims.
         mock_client.api.get.side_effect = [
             {"id": 1, "slug": "p", "name": "P"},
             _api_error(TaigaServerError, 500, "upstream exploded"),
         ]
-        with pytest.raises(Exception):
+        with pytest.raises(TaigaServerError):
             wf.upsert_wiki("p", "my-page", "Content here", session_id=session)
         mock_client.api.wiki.create.assert_not_called()
 


### PR DESCRIPTION
## Problem

`upsert_wiki` promised *"if a page with the given slug already exists it is updated; otherwise a new page is created."* **It could only ever update.**

```python
existing = client.api.get("/wiki/by_slug", params={"slug": slug, "project": project_id})
if existing:
    ... edit ...
else:
    ... create ...   # ← unreachable
```

`/wiki/by_slug` **raises** `TaigaNotFoundError` for an unknown slug — it does not return a falsy value. The exception escaped `do_upsert` before the `else`, so `wiki.create()` was dead code. Creating any new wiki page failed with:

```
API Error 404: No WikiPage matches the given query.
```

Reproduced live against project #9 while creating a `maintenance-triage` page.

## Fix

Catch the not-found case specifically:

```python
try:
    existing = client.api.get("/wiki/by_slug", params={...})
except TaigaNotFoundError:
    existing = None
```

The guard is deliberately **narrow**. A 500 or auth failure on the lookup is not "page does not exist" and must still surface — otherwise we'd silently create a duplicate page on a transient error.

## Why the existing test couldn't catch it

Its fixture returned `None` from `/wiki/by_slug` — **a response the API never produces**. So it asserted against fiction and passed green while production was broken.

This is the same failure mode as the phantom `*_extra_info` fixtures fixed in #129/#130, one step over: there the fixture supplied a *field* the API never sends; here it supplied a *return value* the API never returns. Third instance of the pattern this week.

The test now models the raise, and **is verified to fail without the fix**:

```
--- fix REVERTED ---
FAILED tests/test_server_workflow.py::TestUpsertWiki::test_creates_new_page_when_not_found
--- fix RESTORED ---
3 passed
```

## Changes

- Narrow `TaigaNotFoundError` guard around the slug lookup; `TaigaNotFoundError` imported.
- `test_creates_new_page_when_not_found` now raises 404 instead of returning `None`.
- New `test_non_404_lookup_error_propagates` — a server error must propagate and must **not** fall through to create.
- New `_api_error()` helper: `TaigaAPIError.__init__` takes `(status_code, requests.Response)` and reads `_error_message` off the JSON body, so these exceptions can't be constructed from a bare string. My first attempt at the test failed on exactly that.

## Verification

**568 tests pass** (was 567); `ruff check` and `format --check` clean under the pinned 0.16.0. The 3 `test_integration.py` errors remain pre-existing and unrelated.

## Note

Found while creating the Taiga wiki page for the new platform-maintenance epic — the tooling needed to execute the plan was itself broken. The wiki page is blocked on this landing and the MCP server being redeployed.